### PR TITLE
Publish Stash@v2020.10.21 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.11.3-alpha.0
+  version: v0.11.3
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3-alpha.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: baa296a0e97f971a462ac98ead46df88ae01add892c6953121518a2e36bfb950
+      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 1555e314cf5bc60fdea9ce9a1157f790b48f8599dfb16a71c1b24134f8e44b63
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3-alpha.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 80bf2bb4fbfc6ce44a9548b27eeda8b1cc12602d71e698c15296e4c4d9cc02cd
+      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-linux-amd64.tar.gz
+      sha256: 597d570bb69263c9f72c6e624c6862eb8bcbd6acd9bce65833c14a8e34558f26
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3-alpha.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 31fd319ce5da39001262ce6f2dd59378e6e0626a891898fcdc766af36347c135
+      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-linux-arm.tar.gz
+      sha256: 813f1c48022cff2467018d7f735a7b7a23fd716a24a7df4157ee8356a546181f
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3-alpha.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: db22cc5a04256c34374228f75e972b08ed57423a4c277a9e39a589121f2eb0c3
+      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-linux-arm64.tar.gz
+      sha256: c460995e71659b4b80362ad7b6f808b3ad2a865efe6d75ffbf5fa32139e1a172
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3-alpha.0/kubectl-stash-windows-amd64.zip
-      sha256: 5d8101380aa2cd6455cdaa0eb662d8f44411c5e53bed6880a9204f1943f0ddc0
+      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-windows-amd64.zip
+      sha256: 068f98eb97c5f00539c87c7caa5e0db39e3202aa758500e0d7d77f37cdd42eb8
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2020.10.21

Release-tracker: https://github.com/stashed/CHANGELOG/pull/16
Signed-off-by: 1gtm <1gtm@appscode.com>