### PR TITLE
Publish Stash@v2020.10.29 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.11.3
+  version: v0.11.4
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 1555e314cf5bc60fdea9ce9a1157f790b48f8599dfb16a71c1b24134f8e44b63
+      uri: https://github.com/stashed/cli/releases/download/v0.11.4/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 0423d4f31cc38c8b054fc39e5bf183b11c6c3c036341121bd5a7b4d1c846e01c
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-linux-amd64.tar.gz
-      sha256: 597d570bb69263c9f72c6e624c6862eb8bcbd6acd9bce65833c14a8e34558f26
+      uri: https://github.com/stashed/cli/releases/download/v0.11.4/kubectl-stash-linux-amd64.tar.gz
+      sha256: f4575f70978cc2fd058b5de45aa83df68839430b7223f8414fbc34283a2c66ae
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-linux-arm.tar.gz
-      sha256: 813f1c48022cff2467018d7f735a7b7a23fd716a24a7df4157ee8356a546181f
+      uri: https://github.com/stashed/cli/releases/download/v0.11.4/kubectl-stash-linux-arm.tar.gz
+      sha256: e3d864cc37685b5879d2041c9eee1d6fc817d904af0ed793df3441487225cc7a
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-linux-arm64.tar.gz
-      sha256: c460995e71659b4b80362ad7b6f808b3ad2a865efe6d75ffbf5fa32139e1a172
+      uri: https://github.com/stashed/cli/releases/download/v0.11.4/kubectl-stash-linux-arm64.tar.gz
+      sha256: 368843838b42e957aa01157a2d542a311d93347dd1b4b15cbbd2a716c9a3b5d8
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.3/kubectl-stash-windows-amd64.zip
-      sha256: 068f98eb97c5f00539c87c7caa5e0db39e3202aa758500e0d7d77f37cdd42eb8
+      uri: https://github.com/stashed/cli/releases/download/v0.11.4/kubectl-stash-windows-amd64.zip
+      sha256: b68f9cfa16837809e4864692dbe3cd477821fb4a4f0cb2d80afb8c7ff13c8718
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2020.10.29

Release-tracker: https://github.com/stashed/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>