### PR TITLE
Publish KubeDB@v2020.11.08 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.14.0
+  version: v0.14.1
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 5bd3e5499b256c7d3547d7aae8b59b46a29405b66d4c9c07a73735be435709bc
+      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 2a7a4c403238553dcda2fd1410a3772e59904c6004ff3ff739494958b18b01c1
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: f2727492dd6e2cecb170e11af56b0269f2ce9f8def1a06084a55b31daa002b0b
+      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-linux-amd64.tar.gz
+      sha256: cd3b8680b5ac32f44d9a73604589192e486124d52174dacf382dbbe660d12493
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.0/kubectl-dba-linux-arm.tar.gz
-      sha256: fb06855b91655c85c1eb92779c963ba7bc67b3143190a7074af95589515922df
+      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-linux-arm.tar.gz
+      sha256: 881b155c114feb270e3b4abadc52b21be416e4f30bfec2c27f6e7d0c03d5c84b
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: 0ebac4a1804438f490b544626675c9d1c2982ce02df9fccfed2c7a72e8c1c745
+      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-linux-arm64.tar.gz
+      sha256: 403753aeba8c60c78c99905aa0a70b689e0f781bac57d0018bf83c434c1f691d
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.0/kubectl-dba-windows-amd64.zip
-      sha256: edab53776a2df023e5995f5ae1ef156030b414e1f440e6d0bdfed62fb1be9228
+      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-windows-amd64.zip
+      sha256: cbc1f3bc63307773ef9d2cc6454bfbf3d0cbf08d3cbf9adef4093c34a4d674e8
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2020.11.08

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/22
Signed-off-by: 1gtm <1gtm@appscode.com>