### PR TITLE
Publish KubeDB@v2020.11.11 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.14.1
+  version: v0.15.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 2a7a4c403238553dcda2fd1410a3772e59904c6004ff3ff739494958b18b01c1
+      uri: https://github.com/kubedb/cli/releases/download/v0.15.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 182202c965ecbd5b348d79c4cc4b44e7dda40f10f6789cc85139b3b0fd1810aa
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-linux-amd64.tar.gz
-      sha256: cd3b8680b5ac32f44d9a73604589192e486124d52174dacf382dbbe660d12493
+      uri: https://github.com/kubedb/cli/releases/download/v0.15.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: f09775367839adacf2473a38ef269c35780f892bd819699a013bf0602b3b6ac3
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-linux-arm.tar.gz
-      sha256: 881b155c114feb270e3b4abadc52b21be416e4f30bfec2c27f6e7d0c03d5c84b
+      uri: https://github.com/kubedb/cli/releases/download/v0.15.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 7764b5094f1e2a65e69e48d065939fff361b04a13d6d4042b79bceefd462c87d
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-linux-arm64.tar.gz
-      sha256: 403753aeba8c60c78c99905aa0a70b689e0f781bac57d0018bf83c434c1f691d
+      uri: https://github.com/kubedb/cli/releases/download/v0.15.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 5bae38df0972767d3fc6cdb547e698456ea603f0b091ac75e05c2f933a448366
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.14.1/kubectl-dba-windows-amd64.zip
-      sha256: cbc1f3bc63307773ef9d2cc6454bfbf3d0cbf08d3cbf9adef4093c34a4d674e8
+      uri: https://github.com/kubedb/cli/releases/download/v0.15.0/kubectl-dba-windows-amd64.zip
+      sha256: 98a0943d323f367b6490a5d10d05439f1d02c7c76a7fc94c0c017cc66c01eb1a
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2020.11.11

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/23
Signed-off-by: 1gtm <1gtm@appscode.com>