### PR TITLE
Publish KubeDB@v2021.01.14 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.15.2
+  version: v0.16.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.15.2/kubectl-dba-darwin-amd64.tar.gz
-      sha256: c507ee42b9104a54f6adc239639f3a922465a5fc65046072fc2a93b031b814d4
+      uri: https://github.com/kubedb/cli/releases/download/v0.16.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: a9d8daa15e29cd1246cb35ce6612185ea0bd7ceb33c1a4bab65b906de9789dec
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.15.2/kubectl-dba-linux-amd64.tar.gz
-      sha256: 47be0a1ef3df4146f3296c84215f2d199bb1c7063a6a9eb91528b1955f00d36f
+      uri: https://github.com/kubedb/cli/releases/download/v0.16.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: a1b43decaf945b319616e7781313cdfaca719152ce38748d715b7004a778d531
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.15.2/kubectl-dba-linux-arm.tar.gz
-      sha256: 01231e709f6e8a79fe8812c192558222b00a08c1168ad0e64fc26808ec80546f
+      uri: https://github.com/kubedb/cli/releases/download/v0.16.0/kubectl-dba-linux-arm.tar.gz
+      sha256: a3fb5d39cb0590313c54d38cfc6e88833acf8f84b73fca1be271c539b6a476a2
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.15.2/kubectl-dba-linux-arm64.tar.gz
-      sha256: 831440e9db9234aa1b0d4416a9720eafe276e8975b05e8b892ef009c1f0b57c4
+      uri: https://github.com/kubedb/cli/releases/download/v0.16.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 20b62d6d3490d30e29a63a2f7f3b5660b43e3642bad4e44d351758690790c30a
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.15.2/kubectl-dba-windows-amd64.zip
-      sha256: c0029578c602d737fda3d55132590437294006d5246a4f5ac2a6bba30a7d765f
+      uri: https://github.com/kubedb/cli/releases/download/v0.16.0/kubectl-dba-windows-amd64.zip
+      sha256: 013a981106ac910a2fae67923baaff61fc41fd5d8243894c2c1be4d9c819546d
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2021.01.14

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>