### PR TITLE
Publish Stash@v2021.03.08 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.11.9
+  version: v0.11.10
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.9/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 43992084da73e8f1e5ff43303d07e0e72ad4e8dda79b5cdd063ec5aac22a111a
+      uri: https://github.com/stashed/cli/releases/download/v0.11.10/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 0c1ee01c3ff49545835929a72f55b1cbd8c146a8ef7aedbdd3b74fe43ae12fc6
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.9/kubectl-stash-linux-amd64.tar.gz
-      sha256: c80107c9a56454b01df8fc7bfade275b6fb4baeb51ebbbfa30d0401e36c1af36
+      uri: https://github.com/stashed/cli/releases/download/v0.11.10/kubectl-stash-linux-amd64.tar.gz
+      sha256: 5738bf525adc8fd31850e2993dec77470c385dc217497455468421941080e363
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.11.9/kubectl-stash-linux-arm.tar.gz
-      sha256: 18977449a5701465d9b37d59d2b2cd373af27a32abf06fbafba3c40e0a5da3dc
+      uri: https://github.com/stashed/cli/releases/download/v0.11.10/kubectl-stash-linux-arm.tar.gz
+      sha256: 6f95848e4edbd3b0054c9c5ab04940e9a65364a1cf8c2ef5d3a18a8d55069f25
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.9/kubectl-stash-linux-arm64.tar.gz
-      sha256: 365c3258f3adea8a72a4e74a39df1765613768d226140b8888cc9529808930d0
+      uri: https://github.com/stashed/cli/releases/download/v0.11.10/kubectl-stash-linux-arm64.tar.gz
+      sha256: bd8b2a56a166b439afa9aacab1a6838c77067c3bccdec656225f1200d77ab941
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.11.9/kubectl-stash-windows-amd64.zip
-      sha256: 118ad7c35d9091578aeebb9250afea8d6480890bde3bae2843f05a66ed340282
+      uri: https://github.com/stashed/cli/releases/download/v0.11.10/kubectl-stash-windows-amd64.zip
+      sha256: 78d2278056acf87c5587b34f035c75c917de8215d82d94ea43c64499f810b597
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2021.03.08

Release-tracker: https://github.com/stashed/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>