### PR TITLE
Publish KubeDB@v2021.03.11 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.16.2
+  version: v0.17.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.16.2/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 83235d54043e76165f70bcfa77e97ff2acfa88a5b848307b1b57f57b27a56bbb
+      uri: https://github.com/kubedb/cli/releases/download/v0.17.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: ce96b4682f1180d6c75a0246f59f46eed56bcabac0eccc0f85b505e2ba90f35d
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.16.2/kubectl-dba-linux-amd64.tar.gz
-      sha256: 411ceea08e7809062a16b5cc7481aab6bcd4781479af28d13ef061d6188a5e07
+      uri: https://github.com/kubedb/cli/releases/download/v0.17.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 37f797e3b4a9f9238ef2a6d8f3765759336c3d6152b4c7e65bd4739b2b5e1d0a
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.16.2/kubectl-dba-linux-arm.tar.gz
-      sha256: 6421a9c71299c7da188cdf166060cb2112e78afa832960b6adf844fdd454833b
+      uri: https://github.com/kubedb/cli/releases/download/v0.17.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 1fb75c4dbda98c944d48c88b4842e40d161ccec905f54d46ae0a83c71d6f3c44
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.16.2/kubectl-dba-linux-arm64.tar.gz
-      sha256: 8ff228794ecbe012346d8aa07e74c2a0fadc41b2bac207858544feb23d9af57f
+      uri: https://github.com/kubedb/cli/releases/download/v0.17.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 1f2ac55a996fed3e9db29830560f5796bef8642a0dc0e25020c756b6ee6cca6b
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.16.2/kubectl-dba-windows-amd64.zip
-      sha256: b3bce54e3c299b18dd662e11bb290d27c7633e36b86e2061f818eb2f2a1d793b
+      uri: https://github.com/kubedb/cli/releases/download/v0.17.0/kubectl-dba-windows-amd64.zip
+      sha256: b5facdc35fa8a650d8ad59267bfabc74b3133cd3f9217d156cfea96a876b6d59
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2021.03.11

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/34
Signed-off-by: 1gtm <1gtm@appscode.com>