### PR TITLE
Publish Stash@v2021.04.12 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.12.2
+  version: v0.12.3
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.2/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 89def5307b73854207fb61bf2b46d0265ee06ad71048af4a0c78508489f870fb
+      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-darwin-amd64.tar.gz
+      sha256: ced70086a21da015c107b7527b639936aa0b9fc634415f3c986ae039f8a5db91
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.2/kubectl-stash-linux-amd64.tar.gz
-      sha256: 10e15dc4e2fb7f280c7229f4fccc6f79fac704d2d693b1532f3e6656b3d9fceb
+      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-linux-amd64.tar.gz
+      sha256: 29560a9b40e13d24d48c95d02e9c52240824e368467fa2b88235629c02b3851f
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.12.2/kubectl-stash-linux-arm.tar.gz
-      sha256: 212b86a640ae108b1d6930f8b192848d2c042abc76f308626a24130f4350bdfa
+      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-linux-arm.tar.gz
+      sha256: 082a02245c66e895ac387864c2ab50b16b889cd7b1b4633499b483eba472e95c
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.2/kubectl-stash-linux-arm64.tar.gz
-      sha256: 213d1a3626c42ea8f55dcd363e53eb38c623f7ece14c9d0214af2c33fe67e3b1
+      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-linux-arm64.tar.gz
+      sha256: 4f54c42c040ce1cdf95600eef12585631797edf8bd99c74fbaa54ec23d872f81
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.2/kubectl-stash-windows-amd64.zip
-      sha256: 08bd9373bd651df8b6d8c6a4030b063e033a2f7838c6eefe1188f23fa5c663ec
+      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-windows-amd64.zip
+      sha256: ec51e51740aeac7d93db40f8fa8acbe1673d218cbb3395528b5e28cb651b5aa8
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2021.04.12

Release-tracker: https://github.com/stashed/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>