### PR TITLE
Publish Stash@v2021.6.18 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.12.3
+  version: v0.14.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-darwin-amd64.tar.gz
-      sha256: ced70086a21da015c107b7527b639936aa0b9fc634415f3c986ae039f8a5db91
+      uri: https://github.com/stashed/cli/releases/download/v0.14.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 867f4050227cbdd96304a1ff7d21ef0463df44db3bc088bf4c83f98de496c5fb
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-linux-amd64.tar.gz
-      sha256: 29560a9b40e13d24d48c95d02e9c52240824e368467fa2b88235629c02b3851f
+      uri: https://github.com/stashed/cli/releases/download/v0.14.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 8c05a75a4efd632f1a8d24d7b30e60a9514173d54d0420cfd75f96318c3edb30
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-linux-arm.tar.gz
-      sha256: 082a02245c66e895ac387864c2ab50b16b889cd7b1b4633499b483eba472e95c
+      uri: https://github.com/stashed/cli/releases/download/v0.14.0/kubectl-stash-linux-arm.tar.gz
+      sha256: c648408ce7ada5d3078220ab241123eefc8267c395815ab1f41b5dfd464db2c6
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-linux-arm64.tar.gz
-      sha256: 4f54c42c040ce1cdf95600eef12585631797edf8bd99c74fbaa54ec23d872f81
+      uri: https://github.com/stashed/cli/releases/download/v0.14.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 45414f3daca6504b4abb816c185b6989dd53df808b68d0747ad677f1e9bf3734
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.12.3/kubectl-stash-windows-amd64.zip
-      sha256: ec51e51740aeac7d93db40f8fa8acbe1673d218cbb3395528b5e28cb651b5aa8
+      uri: https://github.com/stashed/cli/releases/download/v0.14.0/kubectl-stash-windows-amd64.zip
+      sha256: f7f3c2156a5631d537fb849bbb3ae573e74a9708d7b34672f8a102f82e730ee4
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2021.6.18

Release-tracker: https://github.com/stashed/CHANGELOG/pull/37
Signed-off-by: 1gtm <1gtm@appscode.com>