### PR TITLE
Publish Stash@v2021.08.02 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.14.1
+  version: v0.15.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.14.1/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 3a48a1a2ea48182e6e9bcc88f160364ed233499abdf2143e7eae30200d3a3814
+      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 8edbac74c4b71f418ddfaf8fe64cb6d1568055b393fe8963e49e6cc5322de422
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.14.1/kubectl-stash-linux-amd64.tar.gz
-      sha256: c2647419e626afc6ed601d591fb0d2cb76b626bc758323eaa336e0fcc1f3ac24
+      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 8506b8668d55da5959a76b7a5ebc5a00a1101061e010963d6c96cfd3cb5fa16b
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.14.1/kubectl-stash-linux-arm.tar.gz
-      sha256: c3b079bef2edac81b43affb52376d181e95abf78522d52ae53e15ec8ab581c1c
+      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-linux-arm.tar.gz
+      sha256: d526ad69bb2a6abc35017724311e25f2bc09dd5f8454e06b0a45ac1c6cad275e
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.14.1/kubectl-stash-linux-arm64.tar.gz
-      sha256: 1be9303d96282ebf16d1c691dd98dc0be591ed5d9da273576aed6fc3660e64f8
+      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 6fe2dad6fea57d929df682d77fec59a97927c7d651389c93f33529405c6d991e
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.14.1/kubectl-stash-windows-amd64.zip
-      sha256: 18facbe17c28147f34a77f20baeba435b4b6afd859ee56a6b2e93c49a4f37cd7
+      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-windows-amd64.zip
+      sha256: b174c3e4b5da73336451ac359f70e698e8a6dfa4b1db673f426d91a309bfcf27
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2021.08.02

Release-tracker: https://github.com/stashed/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>