### PR TITLE
Publish KubeVault@v2021.09.27 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.4.0
+  version: v0.5.0
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.4.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: 9fff1b23368f63062f2cce90528a35e902eb340d219b2f43bda12b048451719a
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.0/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 8e48aeca10807d203ef9532f805abac3a595c43684f133cff18fbfa800cce941
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.4.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: 7cdfadd4a2aece76c3357d6678bb7c74d1c674a69de94258e26cc4047da5cd4d
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.0/kubectl-vault-linux-amd64.tar.gz
+      sha256: 2fbf756395c1ccd46a4039efd5d745f0a7b342cf855a4414d48abed5ad78ca8f
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.4.0/kubectl-vault-linux-arm.tar.gz
-      sha256: 194743917d22e6c991d9e0f68b5d5dd13568e43c5bfee0e166d1d0fa5385bf03
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.0/kubectl-vault-linux-arm.tar.gz
+      sha256: fa1f058241689d0bf84e06b12c524b621d0e1635b4539b7bb04bcce2c061e742
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.4.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: b9f241742cf487df57c4e6b9172cace8e9fea7f3d57ca0ae9d53a5dc2306f032
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.0/kubectl-vault-linux-arm64.tar.gz
+      sha256: 21dec669a5ec7fb173d8c84503542e37d0ecedb979b67d055099137549935aad
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.4.0/kubectl-vault-windows-amd64.zip
-      sha256: f001fe5565a05e7999a1716899ba3bae3171266690cab6c8f6a28dad902870e4
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.0/kubectl-vault-windows-amd64.zip
+      sha256: cf77eb253bfb9499b83db111a9fbf0f32e31a4efb0405c2e321020dd74970b58
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2021.09.27

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>