### PR TITLE
Publish Stash@v2021.10.11 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.15.0
+  version: v0.16.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 8edbac74c4b71f418ddfaf8fe64cb6d1568055b393fe8963e49e6cc5322de422
+      uri: https://github.com/stashed/cli/releases/download/v0.16.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: a54d53e62757a4eee781cf85af9a4379db8cd8aa3c8336b5948b89552f0940e1
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 8506b8668d55da5959a76b7a5ebc5a00a1101061e010963d6c96cfd3cb5fa16b
+      uri: https://github.com/stashed/cli/releases/download/v0.16.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 3fa2ad62710b8a57b28a0bfb1a074cef4ee90f547426187887cd3e3b3444077f
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-linux-arm.tar.gz
-      sha256: d526ad69bb2a6abc35017724311e25f2bc09dd5f8454e06b0a45ac1c6cad275e
+      uri: https://github.com/stashed/cli/releases/download/v0.16.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 99c5e1fc20987ab4cd79513ce1bcfc59cfdc21855a5637627527a50df7679e7e
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 6fe2dad6fea57d929df682d77fec59a97927c7d651389c93f33529405c6d991e
+      uri: https://github.com/stashed/cli/releases/download/v0.16.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 25295ba310660eb63051a471e7397c47e6d0db8a525447690907df81ed106518
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.15.0/kubectl-stash-windows-amd64.zip
-      sha256: b174c3e4b5da73336451ac359f70e698e8a6dfa4b1db673f426d91a309bfcf27
+      uri: https://github.com/stashed/cli/releases/download/v0.16.0/kubectl-stash-windows-amd64.zip
+      sha256: fcacab639c6aab9a7738d5f3a7c30dc594e1a85fbb994a69db24cbcc4a2b6dc1
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2021.10.11

Release-tracker: https://github.com/stashed/CHANGELOG/pull/41
Signed-off-by: 1gtm <1gtm@appscode.com>