### PR TITLE
Publish KubeVault@v2021.10.11 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.6.0-alpha.0
+  version: v0.5.1
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.6.0-alpha.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: 8c1497a3586a69fc3d5a9d2059d467e7a16582a0b04f0057b1d3060285584029
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.1/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 1dc81a2d7c435e17fedca2145b7fba59603989c9e1f60052c4a4dc1ff30be492
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.6.0-alpha.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: 7e9d51370c77c5ffbc4d5783f79accbc5183c6872990a11745751a22f5d46e83
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.1/kubectl-vault-linux-amd64.tar.gz
+      sha256: cf5286b1052d9753063c8b8eef67762a1b567d0ff093f3df2ef0b3d0dbac2c8f
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.6.0-alpha.0/kubectl-vault-linux-arm.tar.gz
-      sha256: 2628ef5bf9303ce1263cb48eb37cb165287d57288a77bd99cb54407f3d06c4af
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.1/kubectl-vault-linux-arm.tar.gz
+      sha256: 236dd6bdbfd1faf7d088a674c55313ad5475a6ab5c93782a68ea11f55de6a60c
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.6.0-alpha.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: 955ca2761f8f8fc2684bf79775ce5deb8713b2e801c0bb578943c42f0b040eb7
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.1/kubectl-vault-linux-arm64.tar.gz
+      sha256: 34bd74973c0756e24713add3ba6666e17c18231bdd01cd92d3d09ba03ea9a98a
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.6.0-alpha.0/kubectl-vault-windows-amd64.zip
-      sha256: 222e9a0120fa399e3b39ea52e1bea075723b921edcb3dd5910d178128d4bc48b
+      uri: https://github.com/kubevault/cli/releases/download/v0.5.1/kubectl-vault-windows-amd64.zip
+      sha256: 4094c3a39062dd2cfd240240281e5eb28cc3226bec0fbba2310516d65309575a
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2021.10.11

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/22
Signed-off-by: 1gtm <1gtm@appscode.com>