### PR TITLE
Publish KubeDB@v2021.11.24 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.23.0
+  version: v0.24.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.23.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: f6a278ff72aec03e7f72d75ee76a1e4796a232a62cc193a15c4684be36aaa816
+      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 263cb0e4f4b2e9038479566a1d63f74e538858471c8e76eaa138e2a7a6d9ba66
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.23.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: ef8186736bc594c81162a9d7566458380bccb146ff59cbee8ab2f45d45196d26
+      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 99dd8671784dadec56577cc65774c391bf4ed9bdd874a6c16a4ca38b68685684
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.23.0/kubectl-dba-linux-arm.tar.gz
-      sha256: e52b152e2acbc45e0bc5faaff5f7feab975055a367ce5463a0864be098b93d35
+      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-linux-arm.tar.gz
+      sha256: a867129e8b6c6161da6108825255aaf91c329b065e31a7c445aa0d6abeea71d4
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.23.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: d3d2ed472b78df51e9c8243335b878e36bf78f0c8d76adaa3f96ab3350cdd483
+      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 939859ed6b8c404d3e01dd5d64f510f3e7bd0c9497330a16e308b29a48851bef
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.23.0/kubectl-dba-windows-amd64.zip
-      sha256: 36ac28884810fb06db2dbe3666472aed803a2d5b45a2b50efb6843d5048997e9
+      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-windows-amd64.zip
+      sha256: b360a8d6b1d36fcf9e3d65ce52d5b34662d3ff8fdcd622494f89d557226dd259
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2021.11.24

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>