### PR TITLE
Publish Voyager@v2022.01.01 plugin

### DIFF
--- a/plugins/voyager.yaml
+++ b/plugins/voyager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: voyager
 spec:
-  version: v0.0.3
+  version: v0.0.4
   homepage: https://voyagermesh.com
   shortDescription: kubectl plugin for Voyager by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.3/kubectl-voyager-darwin-amd64.tar.gz
-      sha256: 010d43ea7ad7cbb48d7c3e3e83c713c65325f9d61fb21ed715d14093f2098a76
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.4/kubectl-voyager-darwin-amd64.tar.gz
+      sha256: 12ba112e30c6dc57c8332b9f9e8d7fad39a79b00f000ac079a600ee5aab55605
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.3/kubectl-voyager-linux-amd64.tar.gz
-      sha256: a9f476f522a1026045f4aea99133a27434429938d4e5886a49fb7ef612319464
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.4/kubectl-voyager-linux-amd64.tar.gz
+      sha256: 68d1620fad08bcd3681e080b4563949cd71c81157d98cd47870f932d24bf7592
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.3/kubectl-voyager-linux-arm.tar.gz
-      sha256: 4b4f30c953c282819ad715ccebcd0b51d49bc7d25436a211426310912e581315
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.4/kubectl-voyager-linux-arm.tar.gz
+      sha256: ac5da8eccc9d2dbf1013aeb69467f03396c93b5f9a1199a18a6e19732968f724
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.3/kubectl-voyager-linux-arm64.tar.gz
-      sha256: 0190805f1ba76efc71f2e78fbe847a3cc04f41ec7fc61ebd2492956d3d311f3d
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.4/kubectl-voyager-linux-arm64.tar.gz
+      sha256: 6f2c01401afe6a7ca6a35f4e9f469a3f012cef516be49a512ad38c67199a5522
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.3/kubectl-voyager-windows-amd64.zip
-      sha256: 34195a13d6eea61085bce7ffde0a17ccae5a976c59a5423d662a452fcc6a9509
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.4/kubectl-voyager-windows-amd64.zip
+      sha256: 48f0defad47512c958fdcc7b983bf5e6d7e2ad390996b08ddfea5c4cdc86afc3
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Voyager

Release: v2022.01.01

Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/11
Signed-off-by: 1gtm <1gtm@appscode.com>