### PR TITLE
Publish KubeDB@v2022.02.22 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.24.0
+  version: v0.25.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,18 +13,28 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 263cb0e4f4b2e9038479566a1d63f74e538858471c8e76eaa138e2a7a6d9ba66
+      uri: https://github.com/kubedb/cli/releases/download/v0.25.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 2a1cffd990e7ba77d5c180c74dfbe601f807252e8652f8c9732cf4acd6d0b2d3
       files:
         - from: "*"
           to: "."
       bin: kubectl-dba-darwin-amd64
     - selector:
         matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/kubedb/cli/releases/download/v0.25.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 074ab5b01610c7610ec2e8ab479469f399354b208c03477243804fc6a606f257
+      files:
+        - from: "*"
+          to: "."
+      bin: kubectl-dba-darwin-arm64
+    - selector:
+        matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: 99dd8671784dadec56577cc65774c391bf4ed9bdd874a6c16a4ca38b68685684
+      uri: https://github.com/kubedb/cli/releases/download/v0.25.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 0be7a9912ecfe149d154f2ff2ec0e17298df18c66358e2056bff4edea184dc91
       files:
         - from: "*"
           to: "."
@@ -33,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-linux-arm.tar.gz
-      sha256: a867129e8b6c6161da6108825255aaf91c329b065e31a7c445aa0d6abeea71d4
+      uri: https://github.com/kubedb/cli/releases/download/v0.25.0/kubectl-dba-linux-arm.tar.gz
+      sha256: cd4342774071f6d7911ba73a9bda6b76f29935071e8b4d43ec6bd60d8f7dce0b
       files:
         - from: "*"
           to: "."
@@ -43,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: 939859ed6b8c404d3e01dd5d64f510f3e7bd0c9497330a16e308b29a48851bef
+      uri: https://github.com/kubedb/cli/releases/download/v0.25.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 7bbed98761ba7094e0a1bb4e62a47d11e838b58299b90da05e3f3631d1a28e15
       files:
         - from: "*"
           to: "."
@@ -53,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.24.0/kubectl-dba-windows-amd64.zip
-      sha256: b360a8d6b1d36fcf9e3d65ce52d5b34662d3ff8fdcd622494f89d557226dd259
+      uri: https://github.com/kubedb/cli/releases/download/v0.25.0/kubectl-dba-windows-amd64.zip
+      sha256: 7d4fa2479c5a45fa6a070bf5782e31f7f99c57bd8449c4a71d4f330014e438c9
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2022.02.22

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/48
Signed-off-by: 1gtm <1gtm@appscode.com>