### PR TITLE
Publish Stash@v2022.05.12 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.19.0
+  version: v0.20.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.19.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: a47e7ea2bbdbb171eef032914925dccd4e135e5a7ff7b9382f5cfc628d8cde6f
+      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 8e9356101e8ba2c44fb8179b7c44ac0486aace633bae598996938a8a09334c33
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.19.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: df11f121a633d1256ad74289e9d1cb1aeb7beea1a208d95afe8c36d951da772a
+      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 4ecb45133327c3d58bf1bbb3c872cf9feaf87c043927789a1e9e850108e95564
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.19.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 8101f48fffd05efd4560944ced091beedaea4de2ab89a3765018717e0d0dc563
+      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 696d04971f9a55da0af63a5ea7606b747ffc92fc475a058097780b267b643daf
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.19.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 4b155f8b3a0d4605e72f79428e19689f21708979dcede8e409109ed68e99d933
+      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-linux-arm.tar.gz
+      sha256: f48f4cd90962ae47c574dd226b710df1c45140a84b5e089222c476a71ea2d61e
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.19.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 58854cf99c740780e0d1a87b557df4680a59d0a4890ca055bc29e27507443884
+      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 016fa2bfed5b0227e24c66720c39a9af823c044f5d2057bc5c9e65f2dab722dc
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.19.0/kubectl-stash-windows-amd64.zip
-      sha256: ed72f3c72b2a957d2cf305408bbf881809b2a9962cbf76147e1a01de9e1d56fc
+      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-windows-amd64.zip
+      sha256: 030f6b8373ba732f68150bc1e8ac9b37fab6136c3b4809aa48181bb9c2ece0a3
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2022.05.12

Release-tracker: https://github.com/stashed/CHANGELOG/pull/47
Signed-off-by: 1gtm <1gtm@appscode.com>