### PR TITLE
Publish KubeDB@v2022.05.24 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.26.0
+  version: v0.27.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.26.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 92f48923f461112850068a556add8d42b7335ca66330fd0bacb091f537544aa5
+      uri: https://github.com/kubedb/cli/releases/download/v0.27.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 29fdd66c9826458db2b7d5d12dd642bbae86f44c712d0de3a01cdc3fcc24fc7a
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.26.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: 6180bba630262c415535ff6ee65b300a3ad1adc6309e44c3cff5048e13f5f2b5
+      uri: https://github.com/kubedb/cli/releases/download/v0.27.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: f026e09977ed24e7da775cd619f32a6ccb92f55c69dd333ff201db7917f52adf
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.26.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: 9cbab15646b7ccffe70b53e41b5b1f81a4f0968ceb2fa06a4505226f3470a71b
+      uri: https://github.com/kubedb/cli/releases/download/v0.27.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: b5ec33dff970956bd2e7816a43db643f6ac9c146030bc9a6fd490c0d9f7e0bb5
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.26.0/kubectl-dba-linux-arm.tar.gz
-      sha256: 847da1f67b9b102d39d1910c9e0042e2ac46786eee031b9d9627364ca29ea54d
+      uri: https://github.com/kubedb/cli/releases/download/v0.27.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 2c4585203b5571765d4d640360b4f83836cefc51461023fb8fa7979dd91e714b
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.26.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: c8014daa1e7c2b0fa69ab4a774b49b6bb417bd0ad864722416b296674c51378d
+      uri: https://github.com/kubedb/cli/releases/download/v0.27.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 01020cad966eb14f61497f3e568791e77a9f3da81ed1e97723835bd0dd2673f3
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.26.0/kubectl-dba-windows-amd64.zip
-      sha256: afbf630289ddf9c9a068e99e708b760028c49259660e69af6de1df13fa92f9cd
+      uri: https://github.com/kubedb/cli/releases/download/v0.27.0/kubectl-dba-windows-amd64.zip
+      sha256: a1ac1457968ee1141c9edd6c78d47af49ef2574e05339d78d61dfd269872fe73
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2022.05.24

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/51
Signed-off-by: 1gtm <1gtm@appscode.com>