### PR TITLE
Publish Stash@v2022.06.21 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.20.0
+  version: v0.21.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 8e9356101e8ba2c44fb8179b7c44ac0486aace633bae598996938a8a09334c33
+      uri: https://github.com/stashed/cli/releases/download/v0.21.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 6a246725780b268d875aecc6e868195662c99dd0e485b7a9e72c89f02c963838
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: 4ecb45133327c3d58bf1bbb3c872cf9feaf87c043927789a1e9e850108e95564
+      uri: https://github.com/stashed/cli/releases/download/v0.21.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 22851e4561fa21ba970dcf4e55342111b622762d23dc4241cccd120613d3521b
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 696d04971f9a55da0af63a5ea7606b747ffc92fc475a058097780b267b643daf
+      uri: https://github.com/stashed/cli/releases/download/v0.21.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: bfa94636d91ad24c90419256dfdbcebb860f30508aad08b3f689d54c48cc1284
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-linux-arm.tar.gz
-      sha256: f48f4cd90962ae47c574dd226b710df1c45140a84b5e089222c476a71ea2d61e
+      uri: https://github.com/stashed/cli/releases/download/v0.21.0/kubectl-stash-linux-arm.tar.gz
+      sha256: b70ddc31b75b66de06ef20d1452b1a9623dfee40ced4106061c82dec18ad64db
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 016fa2bfed5b0227e24c66720c39a9af823c044f5d2057bc5c9e65f2dab722dc
+      uri: https://github.com/stashed/cli/releases/download/v0.21.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: c79f9505361151458a1c74f068410908b3502d04061402b3f02819e4e9455d33
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.20.0/kubectl-stash-windows-amd64.zip
-      sha256: 030f6b8373ba732f68150bc1e8ac9b37fab6136c3b4809aa48181bb9c2ece0a3
+      uri: https://github.com/stashed/cli/releases/download/v0.21.0/kubectl-stash-windows-amd64.zip
+      sha256: 015ba9d08336085d74825c1a3a2a55524c47d007ac38e1132774edbaf1b9a08c
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2022.06.21

Release-tracker: https://github.com/stashed/CHANGELOG/pull/49
Signed-off-by: 1gtm <1gtm@appscode.com>