### PR TITLE
Publish KubeVault@v2022.11.30 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.10.0
+  version: v0.11.0
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.10.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: 225450ed67eba29e92fbc21df0511df41ed70e32a365e4a9c31bb50175f26c96
+      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 789aaf1e732757b9f4dd00bf82a7697f0ed6fc5778582de64eb05c637eb58efd
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.10.0/kubectl-vault-darwin-arm64.tar.gz
-      sha256: 46a504a04ed39bebfdf39ee31eefe7567469f1a3e06cc3a87c310d71d6e0febb
+      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-darwin-arm64.tar.gz
+      sha256: 003bd488a02fc828488d2a51581497b527b8f5c17893e4f63d43848dfaf450bc
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.10.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: 8baa727b6dea57a6e69b6a7425906a842319d2077348ae165264c52181d695de
+      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-linux-amd64.tar.gz
+      sha256: 1f20e6a580d6ef2e20579f81b8a7678166da4a0647cb924dff7319b52c0091d4
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.10.0/kubectl-vault-linux-arm.tar.gz
-      sha256: 2d21a27e0b089acc75fe4561c23891a46d2c0136c54a658e3cc3774bc4856290
+      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-linux-arm.tar.gz
+      sha256: c7f1edad520297d1e423a667709b7793c6a146c6e6f1d2badd1660815de2e9db
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.10.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: 3339ac16099e95ba9a21ee91dd3322d29e3e8b8257c62400d09d746267fbd63a
+      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-linux-arm64.tar.gz
+      sha256: b30eabcbf51b53d6b6559ebe7a99c83f1b04d8a6b11fe8bb61a089fff32890f4
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.10.0/kubectl-vault-windows-amd64.zip
-      sha256: cb9f7a80a570167656d18235b49b835b6bb542992aa5740f5457188c21dc9d89
+      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-windows-amd64.zip
+      sha256: d9d85a54fd0ab9f45349e9311212a2e8ed14a0c74055171c0fe85424ba49efbc
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2022.11.30

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/33
Signed-off-by: 1gtm <1gtm@appscode.com>