### PR TITLE
Publish KubeVault@v2022.12.09 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.11.0
+  version: v0.12.0
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: 789aaf1e732757b9f4dd00bf82a7697f0ed6fc5778582de64eb05c637eb58efd
+      uri: https://github.com/kubevault/cli/releases/download/v0.12.0/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 6131dd2851e0833af7f9d62b178e901d0b621cf1f7f15a78fafe29d25f00d4e1
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-darwin-arm64.tar.gz
-      sha256: 003bd488a02fc828488d2a51581497b527b8f5c17893e4f63d43848dfaf450bc
+      uri: https://github.com/kubevault/cli/releases/download/v0.12.0/kubectl-vault-darwin-arm64.tar.gz
+      sha256: 9b4049042fbf33498bb7b21b3505818652ed634765c9432f7e2d93b7339a8b02
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: 1f20e6a580d6ef2e20579f81b8a7678166da4a0647cb924dff7319b52c0091d4
+      uri: https://github.com/kubevault/cli/releases/download/v0.12.0/kubectl-vault-linux-amd64.tar.gz
+      sha256: 6a3f59b77b30eb1a0b85908f4eec82bec31f72d537d75f62cf47f24aaefa0f61
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-linux-arm.tar.gz
-      sha256: c7f1edad520297d1e423a667709b7793c6a146c6e6f1d2badd1660815de2e9db
+      uri: https://github.com/kubevault/cli/releases/download/v0.12.0/kubectl-vault-linux-arm.tar.gz
+      sha256: c7b880f4d3245c22046e6b3dcdd548d071d54f56e3879ca571f9ed847c0c5f54
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: b30eabcbf51b53d6b6559ebe7a99c83f1b04d8a6b11fe8bb61a089fff32890f4
+      uri: https://github.com/kubevault/cli/releases/download/v0.12.0/kubectl-vault-linux-arm64.tar.gz
+      sha256: fff8ce178c69bb787b8a0aa02b3aa9616534a770f88c4fbabc32dd27bededf03
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.11.0/kubectl-vault-windows-amd64.zip
-      sha256: d9d85a54fd0ab9f45349e9311212a2e8ed14a0c74055171c0fe85424ba49efbc
+      uri: https://github.com/kubevault/cli/releases/download/v0.12.0/kubectl-vault-windows-amd64.zip
+      sha256: e8a342db97893f4b3f6d0518546f0158a2dcc956ea3f6cbae1536cfe588ce8e4
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2022.12.09

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>