### PR TITLE
Publish Voyager@v2022.12.11 plugin

### DIFF
--- a/plugins/voyager.yaml
+++ b/plugins/voyager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: voyager
 spec:
-  version: v0.0.10
+  version: v0.0.11
   homepage: https://voyagermesh.com
   shortDescription: kubectl plugin for Voyager by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.10/kubectl-voyager-darwin-amd64.tar.gz
-      sha256: 6d12f88f935ab57825511f3136d0303238e913fba4921d7445a0efbb14d0f6cd
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.11/kubectl-voyager-darwin-amd64.tar.gz
+      sha256: 29a07212e6a27512df2f07996576a56703127210ee0729a77d31257a008a48af
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.10/kubectl-voyager-darwin-arm64.tar.gz
-      sha256: 1152839d0f5292c3623ad061ec3cc3184fc78696feb74558d8fdd75ff5d51a2d
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.11/kubectl-voyager-darwin-arm64.tar.gz
+      sha256: 7ee2628137b0f09a9769004ecab1866dcb4c4acd36554a604cf4ab3d13f3b8da
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.10/kubectl-voyager-linux-amd64.tar.gz
-      sha256: ebb38630eb688242f7b9b75a7ee83fd50dd7fad77cffaa2f73acc770f8ca9e7c
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.11/kubectl-voyager-linux-amd64.tar.gz
+      sha256: 886c94ef0d8626c57f2949aaf30b9eeb9d0ebe7d96806df8e9dc7721f1efe4be
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.10/kubectl-voyager-linux-arm.tar.gz
-      sha256: 5efde60528364a0577e37f832a4ccb432ee0b1935b060da6c363e06a4323c47f
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.11/kubectl-voyager-linux-arm.tar.gz
+      sha256: cc29a5b45c434ffa97b677b11853f06a47bb534c99d8da712b5b435be4f1b4cf
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.10/kubectl-voyager-linux-arm64.tar.gz
-      sha256: 7d0d57039cffbba79b962b0842862880fa1f243ab32f68c618cfc83a942afa46
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.11/kubectl-voyager-linux-arm64.tar.gz
+      sha256: a8712a72e2efd0ca7092134594b6ec313d7187f9b637086f67dadb43401d8610
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.10/kubectl-voyager-windows-amd64.zip
-      sha256: 9ed60f3c2b3d56b926392b8ca1fdfbc750c17b4423b7cdd1db7318cecd4aee55
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.11/kubectl-voyager-windows-amd64.zip
+      sha256: b020919b90872ff53ae2efe30c1039f2233bd861169d94b2c5d9dbf6330defda
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Voyager

Release: v2022.12.11

Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/23
Signed-off-by: 1gtm <1gtm@appscode.com>