### PR TITLE
Publish KubeDB@v2022.12.28 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.29.0
+  version: v0.30.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.29.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: c109d2edc4d9055e7d5b52d5fd2ccf8a967c6318f3bb7daefec601d1127bdcce
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 0bbdfbb4249bacb9f665d6e7a76c29104c417a74ce9ac5476f5b5b0c0abd8992
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.29.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: 426cce2c100fc8ac817e3cf2b44410e99e00799580382403c39c575ab9390660
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 5524392d2277d7de384f93a492fcc729985e21365ec67ae4e4ef1122f26bf324
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.29.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: 11db641d5ffc81b5f760d3594756a28bc20fac8eba7309914ec915c029b333c9
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: c031314cb17219d65ce3b3e15fc2d22c26a50ac1dafbc9799a6fe07373c9d37a
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.29.0/kubectl-dba-linux-arm.tar.gz
-      sha256: b83981cc2b08e02e1326cc58bcfd22bb6ecb320720b732835d26a26596e26d0b
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 6acd35edb3ac44f45318d350bd722cfad0b9113d945a57e646dab0be17a861e4
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.29.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: e06e4898acc7a2f058ba62ac2acf9eb6de8f84db73ccaf43bcbe3bd9a6e1629e
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 56ec29a39859b34028036645fa78e45c7f8625c3c21160b43cc37230e37807de
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.29.0/kubectl-dba-windows-amd64.zip
-      sha256: 9277ccbaf964acf7ff28c9d604cc67483695bd1d9b31923af0b875312011d688
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-windows-amd64.zip
+      sha256: 10ee76559a8f0df722deec89a180ee9775cc27ab86a1afdbb6a6cedd546b6b72
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2022.12.28

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/62
Signed-off-by: 1gtm <1gtm@appscode.com>