### PR TITLE
Publish KubeDB@v2023.01.17 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.30.0
+  version: v0.30.1
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 0bbdfbb4249bacb9f665d6e7a76c29104c417a74ce9ac5476f5b5b0c0abd8992
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 185fc9aeb38c72b40abd616e2bc9239e2e271331d4dd452fa226efb91044089f
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: 5524392d2277d7de384f93a492fcc729985e21365ec67ae4e4ef1122f26bf324
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 049f9a7d4412b51a3403df03dc9b5f6fbc54d3d030531cb3ca088bc498c710c5
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: c031314cb17219d65ce3b3e15fc2d22c26a50ac1dafbc9799a6fe07373c9d37a
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-linux-amd64.tar.gz
+      sha256: daca70baa786c56837344ec51a1f88b770b49fca6ad952926d5e5a90a40c839b
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-linux-arm.tar.gz
-      sha256: 6acd35edb3ac44f45318d350bd722cfad0b9113d945a57e646dab0be17a861e4
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-linux-arm.tar.gz
+      sha256: 36b53030eae7d7a7bc01a8c138e40369379a2d8e1a727f7352943f033c9aae68
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: 56ec29a39859b34028036645fa78e45c7f8625c3c21160b43cc37230e37807de
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-linux-arm64.tar.gz
+      sha256: c3e2c3ff860975500f39f77f9f6b1e6027f9744e7b80e80ebfb8b9f4ad6e0741
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.0/kubectl-dba-windows-amd64.zip
-      sha256: 10ee76559a8f0df722deec89a180ee9775cc27ab86a1afdbb6a6cedd546b6b72
+      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-windows-amd64.zip
+      sha256: 98777af57211542cd56d6ad237d6b1c5516086e645d2ee71f92eeb990a68d599
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2023.01.17

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/63
Signed-off-by: 1gtm <1gtm@appscode.com>