### PR TITLE
Publish KubeDB@v2023.01.31 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.30.1
+  version: v0.31.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 185fc9aeb38c72b40abd616e2bc9239e2e271331d4dd452fa226efb91044089f
+      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: e5f9605e6efef263776d8c88b6899ef6f0c148913f07eadbf69eb6462ed57de5
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-darwin-arm64.tar.gz
-      sha256: 049f9a7d4412b51a3403df03dc9b5f6fbc54d3d030531cb3ca088bc498c710c5
+      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: d367e1807d282c0d5c23cb58cb6a022686284f26fbcd34f8834d0bbe0ee94e9c
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-linux-amd64.tar.gz
-      sha256: daca70baa786c56837344ec51a1f88b770b49fca6ad952926d5e5a90a40c839b
+      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: dcf2b80e5a8607ac948e1f4d6a03da4352691549ca7f88be9f610fb8985a1835
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-linux-arm.tar.gz
-      sha256: 36b53030eae7d7a7bc01a8c138e40369379a2d8e1a727f7352943f033c9aae68
+      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 961ce2eb87fd33968e467e3237052a4a865a22c3cb0fd5201eaad364b41eccc8
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-linux-arm64.tar.gz
-      sha256: c3e2c3ff860975500f39f77f9f6b1e6027f9744e7b80e80ebfb8b9f4ad6e0741
+      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 1f42623348fd79c9eea47de25632f7a625370ac2a89d0b2b6f19f83f2809ce3f
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.30.1/kubectl-dba-windows-amd64.zip
-      sha256: 98777af57211542cd56d6ad237d6b1c5516086e645d2ee71f92eeb990a68d599
+      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-windows-amd64.zip
+      sha256: 2c249d8ec30c6ebfee9402445629c6ae196d82fdce6db0d618e7f6df7436e29d
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2023.01.31

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/64
Signed-off-by: 1gtm <1gtm@appscode.com>