### PR TITLE
Publish KubeDB@v2023.02.28 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.31.0
+  version: v0.32.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: e5f9605e6efef263776d8c88b6899ef6f0c148913f07eadbf69eb6462ed57de5
+      uri: https://github.com/kubedb/cli/releases/download/v0.32.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 98fa1dbe2b1bd799374ae4d2805df98bbe99670e26af59409fd9c5d96eee7ed7
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: d367e1807d282c0d5c23cb58cb6a022686284f26fbcd34f8834d0bbe0ee94e9c
+      uri: https://github.com/kubedb/cli/releases/download/v0.32.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 2ebacc23cf97944ac3d58b1d4e5a93a04d0821b2674cebbce82d6011889dfa5f
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: dcf2b80e5a8607ac948e1f4d6a03da4352691549ca7f88be9f610fb8985a1835
+      uri: https://github.com/kubedb/cli/releases/download/v0.32.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: ab24059821f54a31314376b2135b1c6ee3dc5c014d33764b696951ae6af851e6
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-linux-arm.tar.gz
-      sha256: 961ce2eb87fd33968e467e3237052a4a865a22c3cb0fd5201eaad364b41eccc8
+      uri: https://github.com/kubedb/cli/releases/download/v0.32.0/kubectl-dba-linux-arm.tar.gz
+      sha256: d6bdd970818d3adf79a689291f6955a12763b1edc2cb2ad87b7ed977804b92fe
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: 1f42623348fd79c9eea47de25632f7a625370ac2a89d0b2b6f19f83f2809ce3f
+      uri: https://github.com/kubedb/cli/releases/download/v0.32.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 70db8db2abd424d3521c967f9bafffd98feeb41f99ba27f0bb41f022c03883ab
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.31.0/kubectl-dba-windows-amd64.zip
-      sha256: 2c249d8ec30c6ebfee9402445629c6ae196d82fdce6db0d618e7f6df7436e29d
+      uri: https://github.com/kubedb/cli/releases/download/v0.32.0/kubectl-dba-windows-amd64.zip
+      sha256: 2ebe9681167a1b267a76519a44e6b4923eab8a17ab41a689b19290e7a795a148
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2023.02.28

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/65
Signed-off-by: 1gtm <1gtm@appscode.com>