### PR TITLE
Publish Stash@v2023.02.28 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.25.0
+  version: v0.26.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.25.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: fc62cfe8c81bd67580b4398110ffa1a2d01811d33f6b0b93de7ac85d59566030
+      uri: https://github.com/stashed/cli/releases/download/v0.26.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 2f1b03bd66a68c833bfe7ed29f7581357d07eaa1b99a65b740227ce269328d6c
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.25.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: 16c1944af878f54da44bb97d95706d93770e64f8832471702a7697a6020b1c9a
+      uri: https://github.com/stashed/cli/releases/download/v0.26.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 2a4baeaadc00de3a917fd933c9f539f0c57c72c981b9df71f49686943a85ba21
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.25.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 9ffc1d667d00b3a627e8d50d455467dcff515a2ec5d4650a9346b8f48a22d3c4
+      uri: https://github.com/stashed/cli/releases/download/v0.26.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 079496ebcfc4b67f1a5f4cc19ec0d82bd04f3acfb53ad933389452d04e7b8c47
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.25.0/kubectl-stash-linux-arm.tar.gz
-      sha256: c3d737f405d4dd84eccf6b56b1cdd75af99efb20a6bb350d0bec0bd3c67623de
+      uri: https://github.com/stashed/cli/releases/download/v0.26.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 1bee2137c8482051f1e82cb2204bf442a8f939a7472e3045f2fa82a8b088a856
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.25.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 232e1dc59c09e33c25e98e4f79b0bfe9c8c250351b7ae86452ca22e6893f2727
+      uri: https://github.com/stashed/cli/releases/download/v0.26.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 720f96e47532900569bcb6d3fa56323612091a2c2624a87df00411369813a319
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.25.0/kubectl-stash-windows-amd64.zip
-      sha256: 9f979e8e930cc534ba8da24a78d5975df2a765f33c700cb297c2c498121ef719
+      uri: https://github.com/stashed/cli/releases/download/v0.26.0/kubectl-stash-windows-amd64.zip
+      sha256: 0f0899cc26111f29180b2b898cdb313db580e6e09669fac8dab7588dfc8c0c31
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2023.02.28

Release-tracker: https://github.com/stashed/CHANGELOG/pull/61
Signed-off-by: 1gtm <1gtm@appscode.com>