### PR TITLE
Publish Stash@v2023.05.31 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.29.0
+  version: v0.30.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.29.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 32bec26e49c3e698bc2afbfdab7fceee855d340366477dc24ce933dafc2be740
+      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: a11b31dac627ed486bd2be384dc75054121bd0bc0cd54d0fc9bfabc748930c26
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.29.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: f053f6d60d346645daf0faff049a9b2f9913930d46b5503fb6690c09b707c3cf
+      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: bde68cab88dcf57d1f7ea2dfc7cb7e22f535188a28ef2229235a8ecac7c808df
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.29.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 267728fee33ce85a4080f6f87a741efa38d73c7ede1fc482c6a2261324f04d0e
+      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 781f6e976ccbd7e3743a20dbc3e5c879f4f3722592e4d1505ccfc6e0a50d26d3
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.29.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 1e3e90bbb1f34980053f1cc76a0a20a2f75cd31a5e490174a607522f6389d8fa
+      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 164f04d01c5f3b6af34af46ec4441dcfc6a6090f2a12a12e1dad9b485e4d1523
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.29.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 95ce58c99288a3cab9aec23b2b1d4f80d72b1b4fc5bfa70da225dda89f5c4e72
+      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 56fda541b3087cb8a8e6269c1aeb071dace141b820e748797ecb8fdb1a7aee79
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.29.0/kubectl-stash-windows-amd64.zip
-      sha256: bf29c3e8ace53aed8fb22f7d7ef74583990dcc1a685098538f11bc74b2b5f169
+      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-windows-amd64.zip
+      sha256: 9bee252db47ab0cd3a1e2b6932481a1f7f4593fe8e92d3f0e302e5fbf2f0b272
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2023.05.31

Release-tracker: https://github.com/stashed/CHANGELOG/pull/66
Signed-off-by: 1gtm <1gtm@appscode.com>