### PR TITLE
Publish Stash@v2023.08.18 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.30.0
+  version: v0.31.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: a11b31dac627ed486bd2be384dc75054121bd0bc0cd54d0fc9bfabc748930c26
+      uri: https://github.com/stashed/cli/releases/download/v0.31.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 18707b98b8f8a346b6eebcd2fe649084a2a97402b2e5961d066e01b028e5908c
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: bde68cab88dcf57d1f7ea2dfc7cb7e22f535188a28ef2229235a8ecac7c808df
+      uri: https://github.com/stashed/cli/releases/download/v0.31.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 1dd9ca047c7ad60de1355fdf0d32a5ebc01a7b3c9c5f4829b9192e1ce06fb768
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 781f6e976ccbd7e3743a20dbc3e5c879f4f3722592e4d1505ccfc6e0a50d26d3
+      uri: https://github.com/stashed/cli/releases/download/v0.31.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 2d68ff539be07a854a3b3a0f3b29420b1ec5b647589cd35ee76789c897211dfa
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 164f04d01c5f3b6af34af46ec4441dcfc6a6090f2a12a12e1dad9b485e4d1523
+      uri: https://github.com/stashed/cli/releases/download/v0.31.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 6822c63efdfbb8c4662b055484703a2bff4b30aae27b54ccb0ab7f2ce6364f66
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 56fda541b3087cb8a8e6269c1aeb071dace141b820e748797ecb8fdb1a7aee79
+      uri: https://github.com/stashed/cli/releases/download/v0.31.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: a713bc2e36c31d1b6132f5da06190ddaffbeb99f1699f522f9cd50da22d249bf
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.30.0/kubectl-stash-windows-amd64.zip
-      sha256: 9bee252db47ab0cd3a1e2b6932481a1f7f4593fe8e92d3f0e302e5fbf2f0b272
+      uri: https://github.com/stashed/cli/releases/download/v0.31.0/kubectl-stash-windows-amd64.zip
+      sha256: 086ee646538277a69f84e91bea0623babe467a5cc488f8bfad97538aaf79fb82
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2023.08.18

Release-tracker: https://github.com/stashed/CHANGELOG/pull/68
Signed-off-by: 1gtm <1gtm@appscode.com>