### PR TITLE
Publish KubeDB@v2023.12.11 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.37.3
+  version: v0.38.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.37.3/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 930ee196b898678b66254a723054340dbddfd432d4bcd0b1c77cd84d86853965
+      uri: https://github.com/kubedb/cli/releases/download/v0.38.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: 022472b6e359ae498cfb8646e239b3ccb753db7e415afe2628c577847a140ab1
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.37.3/kubectl-dba-darwin-arm64.tar.gz
-      sha256: f7b2090a5d994dda8858cc6a528cac7581c277ff907d3dd7ad8d7f1bd7adbab2
+      uri: https://github.com/kubedb/cli/releases/download/v0.38.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: bde254c6c01ecb9fcb77b6d298bcac5bcf0e0ee2e089c8f543a8829678a11df9
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.37.3/kubectl-dba-linux-amd64.tar.gz
-      sha256: 3024bf2cdc07ca08666b419fe640a6037f0a6050e222ffbe4a82f01272df807a
+      uri: https://github.com/kubedb/cli/releases/download/v0.38.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: efd804a8ea5b9afa0c1f189dded42c15ea46bba475861c83f2c3b41f0d0fac1f
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.37.3/kubectl-dba-linux-arm.tar.gz
-      sha256: 7df8c214af40340299851bb4651ff99016e763b2755aba85d711b03846bd14ea
+      uri: https://github.com/kubedb/cli/releases/download/v0.38.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 69a569142a883b03853b06d429e7939dce3116518111bfa135233d33e1dacfa3
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.37.3/kubectl-dba-linux-arm64.tar.gz
-      sha256: bee445d3933a52468f9f115ee19976d5dc259f516bdab1cf4fca37658a0ac4ad
+      uri: https://github.com/kubedb/cli/releases/download/v0.38.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: f38e44e6fd3174349c06bb2c738f5719cca2283da7dafce5e6c4b5147bef92cb
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.37.3/kubectl-dba-windows-amd64.zip
-      sha256: a24c40c03f79912321de22d9aa8276abe7827ad9505657415a8aedb9cc948ec5
+      uri: https://github.com/kubedb/cli/releases/download/v0.38.0/kubectl-dba-windows-amd64.zip
+      sha256: 0c23984602adc067c6e2921484935913ff4e191891a7af060e0819292a7b8bcf
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2023.12.11

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/77
Signed-off-by: 1gtm <1gtm@appscode.com>