### PR TITLE
Publish KubeVault@v2024.1.26-rc.0 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.16.0
+  version: v0.17.0-rc.0
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.16.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: 430c0001d5df0a0bfab90928395933d535ea340d1beefa9cbe4a2c8e868f9adc
+      uri: https://github.com/kubevault/cli/releases/download/v0.17.0-rc.0/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 1a2a30a1b6f17c43d67d88250f8ad68c98c9b1e9da0de87698bcebec11d44644
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.16.0/kubectl-vault-darwin-arm64.tar.gz
-      sha256: ab70948c106651f60015600b1032d0d07ca43bd0512335a4bd242b99b35667bb
+      uri: https://github.com/kubevault/cli/releases/download/v0.17.0-rc.0/kubectl-vault-darwin-arm64.tar.gz
+      sha256: 21f3191c44cb57d21060067cb078375a613835ebb20085891bdfc88a77d5c963
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.16.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: 8fabf15972b43a814ef3ec0e25d039fab2c6740848c523d7d122cd20daabc267
+      uri: https://github.com/kubevault/cli/releases/download/v0.17.0-rc.0/kubectl-vault-linux-amd64.tar.gz
+      sha256: 7007f03a3335932289e87db4f2a3cd5cb4af0444a1b878ad9a908dcb9357570a
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.16.0/kubectl-vault-linux-arm.tar.gz
-      sha256: 99857203662f0d1f06e1ed6a53684fdd37098775b8ece6f95425994eb94cc1c3
+      uri: https://github.com/kubevault/cli/releases/download/v0.17.0-rc.0/kubectl-vault-linux-arm.tar.gz
+      sha256: e27574b417d08eab964b8594e837f589fbe8b05e1ef5d266b9134716f9c9d0c7
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.16.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: 2a9b721cdc3a24585e2a680bb53ea1b8139eae075eb883980d3d82cba24634e9
+      uri: https://github.com/kubevault/cli/releases/download/v0.17.0-rc.0/kubectl-vault-linux-arm64.tar.gz
+      sha256: 6a01effbb9b47ddd1f5c4ef29610742e6c23a3fb0f3fa6fe2e74fff4ec7ba7a5
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.16.0/kubectl-vault-windows-amd64.zip
-      sha256: 2f2604dfc5a8e8841e631c26666d742fcec72b4a5e7c2941ffa0ee2cbb50ed56
+      uri: https://github.com/kubevault/cli/releases/download/v0.17.0-rc.0/kubectl-vault-windows-amd64.zip
+      sha256: c648f5af42de404040dca9d98d741131eb3b1b7d0a6cb41fae3c91243822fc07
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2024.1.26-rc.0

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>