### PR TITLE
Publish KubeStash@v2024.2.5 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.3.0
+  version: v0.4.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.3.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: f98a488053b543c95e080a392ab9ec3ccd62e6cf94b322eada8eeee93d45a056
+      uri: https://github.com/kubestash/cli/releases/download/v0.4.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: c6a8a8003c0c587ff62ffba812d875448b29ef0db5eba7dc2056b1148b6b8b7d
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.3.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 59fe035f267c278cc7af34234d4839d458bd88379e0b4f9939f26c3ad6422863
+      uri: https://github.com/kubestash/cli/releases/download/v0.4.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: d073162e8a1a1bb1f0ced35b166d0aa25e72aabdc952ed1cc05c6fa3b3a1994d
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.3.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: 629f81c0f3892e990a4b6ed1eaf723b10be4836d7ebc1758f249580a5479507f
+      uri: https://github.com/kubestash/cli/releases/download/v0.4.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: 070392a727483efd18cdad3e33a91717094973fafc468b0d7b2981b72eea9dd9
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.3.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: b0f2fadc3620705da01fc40a836d302a4253651ded0e0694452ef3e4537f3344
+      uri: https://github.com/kubestash/cli/releases/download/v0.4.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: bb4e4e6f3928de7f0f064f431b0b20849ce5cb96a3b0a38cb149eca9cda1fd6a
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.3.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: c48d65f1f8809b615fc6e2d331e7ffef2d40409679a134734238fb87009e9512
+      uri: https://github.com/kubestash/cli/releases/download/v0.4.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: c92e7e6ce3a1c0ec5e92127ba39605e853afab2e714687d72309d272893e0899
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.3.0/kubectl-kubestash-windows-amd64.zip
-      sha256: 42fa356bb26ffd1dacd4e49922919e416a59464f2325e857bdbc3fcf6ff28673
+      uri: https://github.com/kubestash/cli/releases/download/v0.4.0/kubectl-kubestash-windows-amd64.zip
+      sha256: 3d1c2c1b2884d723a6e8c622a5ea95ab9b82323c8113a7aa37e4b8ff23023976
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2024.2.5

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/10
Signed-off-by: 1gtm <1gtm@appscode.com>