### PR TITLE
Publish KubeDB@v2024.2.14 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.41.0
+  version: v0.42.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.41.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 054c958b65da835735c35c86e1ddfdbd3c3c189f16b9e19209878d934e9836b7
+      uri: https://github.com/kubedb/cli/releases/download/v0.42.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: cda2451a93cfb495493c6bb7d93e13d67dae5da0063207cffe4176e414e2d9d9
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.41.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: 6e96e8c8eb63594eb8d642ba77837a7ff9638c8233d0bfd2c65dcb770a2e7ea4
+      uri: https://github.com/kubedb/cli/releases/download/v0.42.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 06f429b8b8ac254baef888fa1bc9e01214d3f625bcf2927aa5df6fc1613ed20d
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.41.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: ab6fa97e5253315f613798f797f25d2ff9dc34344ca53c26cdcdd3645647f6e7
+      uri: https://github.com/kubedb/cli/releases/download/v0.42.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 67232ef053c6dc4b291a6059cf2834282c43bad19dc721c7b477dd4bbbaca932
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.41.0/kubectl-dba-linux-arm.tar.gz
-      sha256: 273a3d56b611a1d721a7291aead83dbbd3da2b22d57dd8694397b2ebc0a1ac0b
+      uri: https://github.com/kubedb/cli/releases/download/v0.42.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 6051d08f92b7743597aaf724ff6316f5d50846a7671d89fadf53dee61957b438
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.41.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: df853d727edce447e9db9fd04da47d61f4c1d4ed0c10fb1e63ec7a418c5d6b09
+      uri: https://github.com/kubedb/cli/releases/download/v0.42.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: af728f2bc1278d055a53bb037b37ab8adaa35bb01ff59afa659b6a47c57431f8
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.41.0/kubectl-dba-windows-amd64.zip
-      sha256: d9de09ca4a0dfcfe0b795653f45d7bd4540006c0b95e25473c4cc615d30f7b98
+      uri: https://github.com/kubedb/cli/releases/download/v0.42.0/kubectl-dba-windows-amd64.zip
+      sha256: 51a8edf7de3ac03cbe09d479763284a79a08780a434464d7215ee27ff7aea88a
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2024.2.14

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/85
Signed-off-by: 1gtm <1gtm@appscode.com>