### PR TITLE
Publish KubeStash@v2024.3.16 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.5.0
+  version: v0.6.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.5.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: e17c75a5055cae8a2da6ccdffa8f6150a212e673b34c4d9795f5082a7cfdbbfd
+      uri: https://github.com/kubestash/cli/releases/download/v0.6.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: 8a1588534040b8d30d1cbae0a6ecba308eb3c10a30bb31c86471d8d1fa9cbb06
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.5.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: f55d1c0545d6512d306a1da6c661470b2eaa9bf3b9756f4126eacebcd0249c2a
+      uri: https://github.com/kubestash/cli/releases/download/v0.6.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: c1b7017906c05daabe9c8c673b3e9ee48cd57ad3ee73195511d6ac32e149c3ed
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.5.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: 90fc16b40fdf66b7f1e828f2b0d6a2d87763b79913896745ef5176c05f246acf
+      uri: https://github.com/kubestash/cli/releases/download/v0.6.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: ea38f6ccc4005ecc3959cd7b7dc381aea4af4aad316267305f2edee56949c033
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.5.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: 6276a1b25881ab474ac13bbb52da5054ceaa7b8a7afe348a4235154484272032
+      uri: https://github.com/kubestash/cli/releases/download/v0.6.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: 8b5367e3810a8ab24900873399b5d55ff4e7615251b736d72ac00d9d5253dddb
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.5.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: 28c40c86f59423e7bd5350f9cce3088764a554bdfb334238c2303b92a111d13d
+      uri: https://github.com/kubestash/cli/releases/download/v0.6.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: e315bc6bb68d344b435e333ec73c12f2fa9047b4dcecd3188ff078d3a891b383
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.5.0/kubectl-kubestash-windows-amd64.zip
-      sha256: 1a3946467dfe442fd0d554872f429aa83f965b321d8bf99ac040ca7bdebf0a7c
+      uri: https://github.com/kubestash/cli/releases/download/v0.6.0/kubectl-kubestash-windows-amd64.zip
+      sha256: 629328f109869c294f63c8b3b318a29dc725fa586253a5e48616091c63c45ff7
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2024.3.16

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/12
Signed-off-by: 1gtm <1gtm@appscode.com>