### PR TITLE
Publish KubeStash@v2024.7.1 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.7.0
+  version: v0.9.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.7.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: 445fc83be70d0d54d0f5c2601dfc63267980f5c80b72d99e1979a16c5a996c66
+      uri: https://github.com/kubestash/cli/releases/download/v0.9.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: dcac0f97401eec58d7a18f092b1ff80e47511079bac00d6aa30c733b176c5db2
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.7.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 5a27629391893108f426d27dfde6da5dcb5418da0767cce6f9912d92f4cef091
+      uri: https://github.com/kubestash/cli/releases/download/v0.9.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: 46750f19380c158b52ecc9dfb8be089b51d12f5429ebf8a61e3de6a515c92486
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.7.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: 386bc4dacc1428f9ba10b59bff507fee1233bf1cc1e035db6231359f0218518e
+      uri: https://github.com/kubestash/cli/releases/download/v0.9.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: ff28a118d02e093043c150ca5a8be449cf8c4fadb2fec8223a7707ae8e0e1b26
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.7.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: 532bb539ac67a4b4ee0710cc15192aa0f2827bceb49f1572b3470b80c0a1147e
+      uri: https://github.com/kubestash/cli/releases/download/v0.9.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: 349dd6c10c9b43de3c7ca5fc20e0504cedd9254a174d94103fa75dbc4ee1b95f
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.7.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: e41114106779f29983f78445e56ad55511e39d43c8ea9e30c46f3d6cffcfd7c4
+      uri: https://github.com/kubestash/cli/releases/download/v0.9.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: 96599c80042791555bfcb371f8b3966aad6c925e7f2b33b58e3b01e6f0c6ddc8
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.7.0/kubectl-kubestash-windows-amd64.zip
-      sha256: abb129c32f8822c9276f91699094d2d30f10fded9bf1892820e2643492bad2ba
+      uri: https://github.com/kubestash/cli/releases/download/v0.9.0/kubectl-kubestash-windows-amd64.zip
+      sha256: 9e515b2f52e00a3711cf3f333fcb91f68bad3d203c3d308114ad2f3c4b49d171
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2024.7.1

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/15
Signed-off-by: 1gtm <1gtm@appscode.com>