### PR TITLE
Publish Stash@v2024.8.27 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.34.0
+  version: v0.35.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.34.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 3af86a3ea14f4cd3c497a8cffe31c6fc96432cac31ed91f9b220f0562de5ecc5
+      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: e2c58d6be9dd0699635de388669a73b4124fae965f245f18dab6c417701fd529
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.34.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: 48b230091c49cf04e25c01c36e849995cb87819efe333985dbbd80dbef71ea9e
+      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: f909fcccd1f0be50098ffb974fa14660479a8d8d9d5d473daaf03cf5b2186a61
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.34.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: ce4e6dc60bf985e557e20d51d74c4220a7b9c62b5615b776eb7791a49fd6b280
+      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 2936793c43f4340f661a48d875f383a69d877fabdad473698df09c574e020652
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.34.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 445ca3dddc48939eb352395510927897b036713e1dd418e2bc4a936756b7e967
+      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 0804de809d19e2099caaebf3ee2c2d62c3538c9eda2231ed21f717a4dfa0f3d1
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.34.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: f56f55d2b923e9d8c6c3cbfe4f874651105acf50eed15ab6365fce90781d9c46
+      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 6aa7f00baaec3c42170dff01d42918c190aba7900c2bc55ffc6dea697df18871
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.34.0/kubectl-stash-windows-amd64.zip
-      sha256: 540e9824b51efcdb09345d4bc20952d358264727a125c846191209f97499da94
+      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-windows-amd64.zip
+      sha256: 01bd9cd1398783a85d7d3fbe07f4183694f57ad3999d2b26dbbfd38bbbde5622
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2024.8.27

Release-tracker: https://github.com/stashed/CHANGELOG/pull/75
Signed-off-by: 1gtm <1gtm@appscode.com>