### PR TITLE
Publish KubeStash@v2024.8.30 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.10.0
+  version: v0.11.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.10.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: 5b158bb5b54bfb7fcbc9bd29bae373a89c9c4dd983eb39d744ce1028f2bcbcef
+      uri: https://github.com/kubestash/cli/releases/download/v0.11.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: 8a6a2b90c59d711282b25b39509e6ab69b1cb2d5f1f2536733fb22a0cf8304e4
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.10.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 90ccf246705a565c08a315d8610ca410a00f5f9fdd91ee53f34ea2b05139a4ee
+      uri: https://github.com/kubestash/cli/releases/download/v0.11.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: 2c81b65f754cd780a4269240f8e7e755baf84d1bef02f54f32095a60e3cd20ea
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.10.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: e650411b82c896f05cea9ac70888858c82ae20be9fb84f7400c2fd2cd1c1ff04
+      uri: https://github.com/kubestash/cli/releases/download/v0.11.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: e1bd98e8b29aeffd723633d6d59b5b2c81a77ac03574fbb0e50ec5de8b544764
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.10.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: 12ef1772f9ee42c2487530cce99250de08fadf5c493a36f9ebbca4e06a5fa3ba
+      uri: https://github.com/kubestash/cli/releases/download/v0.11.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: 49ccbd6059f08d63973b26ba2b5df0a6a7bf21a0c24488daafc9c8bf550a957b
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.10.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: 84a5368302b5d27baeaec8a6b7a14e26a3973b8221a37c4f65be8603934b225b
+      uri: https://github.com/kubestash/cli/releases/download/v0.11.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: 96408caf84600a84862e3406cc01b695a098e24e4e647557f11cab668cc8ef88
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.10.0/kubectl-kubestash-windows-amd64.zip
-      sha256: 85d9d5a3c73abd2e533d485e650011e8caead08a3b3d5a8e9a66159f5f7bed25
+      uri: https://github.com/kubestash/cli/releases/download/v0.11.0/kubectl-kubestash-windows-amd64.zip
+      sha256: a8e4622c642ba61ff4966195d865814a719da3a5f259fe37bfcc3766b55de1ab
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2024.8.30

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/19
Signed-off-by: 1gtm <1gtm@appscode.com>