### PR TITLE
Publish Stash@v2024.9.30 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.35.0
+  version: v0.36.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: e2c58d6be9dd0699635de388669a73b4124fae965f245f18dab6c417701fd529
+      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 3caef176ed8b3494abe300b4af655cae3f83788f811f6788a7be2aa925257ac8
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: f909fcccd1f0be50098ffb974fa14660479a8d8d9d5d473daaf03cf5b2186a61
+      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 42fa5b4b516eb69c86e5a91d778fe87a08e7c2ab240970eefd6ba3e5d1cf14f8
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 2936793c43f4340f661a48d875f383a69d877fabdad473698df09c574e020652
+      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 1a69623cbb59efca568337522b91aeafca07065ca5b0c80a2f5a720e36bf4bce
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 0804de809d19e2099caaebf3ee2c2d62c3538c9eda2231ed21f717a4dfa0f3d1
+      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 2d5c7cc9f291d5e063a148191ee7d29c669028e6b630b933be1087f5d5ced5ae
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 6aa7f00baaec3c42170dff01d42918c190aba7900c2bc55ffc6dea697df18871
+      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 7d77b2522ff33bdb590c4b300fa221dc25f33cdf74482a552e2bd894785c5c0f
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.35.0/kubectl-stash-windows-amd64.zip
-      sha256: 01bd9cd1398783a85d7d3fbe07f4183694f57ad3999d2b26dbbfd38bbbde5622
+      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-windows-amd64.zip
+      sha256: 0b1f4551f8d218d2b6597706a7b86bbc3a40458d9b92c594e7a2a9bf01767695
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2024.9.30

Release-tracker: https://github.com/stashed/CHANGELOG/pull/76
Signed-off-by: 1gtm <1gtm@appscode.com>