### PR TITLE
Publish KubeStash@v2024.12.9 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.12.0
+  version: v0.13.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.12.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: 803bca1875a78399ca6adc0fb8fd137fe0faf64bbbfb21379aff452743714237
+      uri: https://github.com/kubestash/cli/releases/download/v0.13.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: 934e9302d3e12f2adbad486cc91bd76f79d8a6b133794f836489b37a0e441b3b
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.12.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 461e30cb3a45c823a6b62a4f5a2ad475f405516226d94c08dfb2310b57df5225
+      uri: https://github.com/kubestash/cli/releases/download/v0.13.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: 0110b46b74b261c14929022460e6bb122db51c63770d390862d3f8396086642d
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.12.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: 215f9dbc411cff78272175052223d9e4eb6c82b7baede88d7a07e217c5caeac4
+      uri: https://github.com/kubestash/cli/releases/download/v0.13.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: f5211c9f4619f291956603430d084cfc2effd7da9ded50890d7b436766fab64c
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.12.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: b7123d156935f36dbea08a308120df2ad51a3f55e760d54971917b503436dc5e
+      uri: https://github.com/kubestash/cli/releases/download/v0.13.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: 147b7f5286f3106f72b815c5880176be46ef4e83aacbf0db487ac266d7930b94
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.12.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: 1d48bd05faa392d5c40199110e21271492327c5d9b451229d96831794a1e0fb1
+      uri: https://github.com/kubestash/cli/releases/download/v0.13.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: 9e700ffaee832f847dc6d3bc8dfc0034f1cb31404231036194be9b253dfd8952
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.12.0/kubectl-kubestash-windows-amd64.zip
-      sha256: aee58275899e213fa046c49d33bf4bfb8f9ba84fefce7c9ed4644d5019300f9a
+      uri: https://github.com/kubestash/cli/releases/download/v0.13.0/kubectl-kubestash-windows-amd64.zip
+      sha256: aa093927e5940d9b282381ecbf503db12e76fb718781780cfe713f4665625c1a
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2024.12.9

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>