### PR TITLE
Publish Stash@v2024.12.18 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.36.0
+  version: v0.37.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: 3caef176ed8b3494abe300b4af655cae3f83788f811f6788a7be2aa925257ac8
+      uri: https://github.com/stashed/cli/releases/download/v0.37.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: ec35e3d5efbdd33c695054d1d0bedf966bb3462873b2b3cdadd90791db454c2c
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: 42fa5b4b516eb69c86e5a91d778fe87a08e7c2ab240970eefd6ba3e5d1cf14f8
+      uri: https://github.com/stashed/cli/releases/download/v0.37.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 18f08e4a43b105d885ab6bff88f74b6971632a964b7d3451056e78b8f7d05ffd
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: 1a69623cbb59efca568337522b91aeafca07065ca5b0c80a2f5a720e36bf4bce
+      uri: https://github.com/stashed/cli/releases/download/v0.37.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 5095bd564354d95cae706474adbfea3bd17b2a4cfc4f53d3d20dffc40fc84de6
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-linux-arm.tar.gz
-      sha256: 2d5c7cc9f291d5e063a148191ee7d29c669028e6b630b933be1087f5d5ced5ae
+      uri: https://github.com/stashed/cli/releases/download/v0.37.0/kubectl-stash-linux-arm.tar.gz
+      sha256: 8ff0eeaebe1f9f332862d9d1961b52ab9541c738d68ce9abca4025dcd1e9b9e6
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 7d77b2522ff33bdb590c4b300fa221dc25f33cdf74482a552e2bd894785c5c0f
+      uri: https://github.com/stashed/cli/releases/download/v0.37.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: d994e1f2f10bc8006307c744e556e0b180f7a304cc7fed232a6fb8ac4a5f270e
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.36.0/kubectl-stash-windows-amd64.zip
-      sha256: 0b1f4551f8d218d2b6597706a7b86bbc3a40458d9b92c594e7a2a9bf01767695
+      uri: https://github.com/stashed/cli/releases/download/v0.37.0/kubectl-stash-windows-amd64.zip
+      sha256: f6c3ebca929bfb568de2ecebbd73eb22065ef11e03a5c92f4d982834211d277a
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2024.12.18

Release-tracker: https://github.com/stashed/CHANGELOG/pull/77
Signed-off-by: 1gtm <1gtm@appscode.com>