### PR TITLE
Publish KubeDB@v2025.1.9 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.50.0
+  version: v0.51.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.50.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: cabb373fa4f1949aae1d50f2fe23e89c08ee8899c6ab53820834dc3bf111f2c4
+      uri: https://github.com/kubedb/cli/releases/download/v0.51.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: c7b283a79ac571a338f1ba9cfdce10ab354e123efebf1698f5c52cf91a7fa4e2
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.50.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: bfb919e35a959340de0143f0f999aef747611dca2dbc0cbbb32d7ab909db9850
+      uri: https://github.com/kubedb/cli/releases/download/v0.51.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 77dd30e8be7808ac89c431b5b20082cbdaf5a6344f29fa4f694e9f32ff901cd6
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.50.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: 90e07494b617eef075f55feb53d314072526307e3e13eb9a8b3b296b59b7ae58
+      uri: https://github.com/kubedb/cli/releases/download/v0.51.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 4ba704acec05de64bc7b75a258262f3e14edbb12b2c0b6ac43aefa8410ea1b4f
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.50.0/kubectl-dba-linux-arm.tar.gz
-      sha256: 171adb3da6bfc09e5b69f8577a2caa7e8f818284897bb3d80965f48642c02c83
+      uri: https://github.com/kubedb/cli/releases/download/v0.51.0/kubectl-dba-linux-arm.tar.gz
+      sha256: e187781ad85f6876360dc7754ff4a175c16c83cddbef1beb56dd6694d5419835
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.50.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: 7f390295dfb66ca6263a0cb607696e5604a2087d415ebc2825bd6708e9baed54
+      uri: https://github.com/kubedb/cli/releases/download/v0.51.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: e7bf4a9d839d284f02d8f2544d6c6198dad0ee0c77c21be02de9f9cbfe0c5164
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.50.0/kubectl-dba-windows-amd64.zip
-      sha256: 4f14aeb83e19f5dc32bb2e9028eef27bcc9733c4abb63956c894280888064ed8
+      uri: https://github.com/kubedb/cli/releases/download/v0.51.0/kubectl-dba-windows-amd64.zip
+      sha256: 8a5ffea5c227e774aad12e761e44af2ce08692b2d2ae5cbcd133c64a88798413
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2025.1.9

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/105
Signed-off-by: 1gtm <1gtm@appscode.com>