### PR TITLE
Publish KubeVault@v2025.2.6-rc.0 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.18.0
+  version: v0.20.0-rc.0
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.18.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: af816eaa49d9f40c602a6abacb72c58e9d25b70838f977b87283522e81cbada2
+      uri: https://github.com/kubevault/cli/releases/download/v0.20.0-rc.0/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 0fc7c688119a7c5ac0343b39a8ef54871ef335e19cd4973b95853c19abc48d92
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.18.0/kubectl-vault-darwin-arm64.tar.gz
-      sha256: c838f44645d0a6a1529e6a92184ddb6054a3122ad47d6b8d202cb0d0337a1868
+      uri: https://github.com/kubevault/cli/releases/download/v0.20.0-rc.0/kubectl-vault-darwin-arm64.tar.gz
+      sha256: 3c0e009279fba65934fc539477a88a3863abc99570c5851c361e798552954871
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.18.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: c4553ba72bcb9a9d46357906b60cd251b506edc18482b1d992833f10e17fe950
+      uri: https://github.com/kubevault/cli/releases/download/v0.20.0-rc.0/kubectl-vault-linux-amd64.tar.gz
+      sha256: b998afc47a6ea4e3a65a5ff246d36ace356499a7b68726dcae03f420ac77c216
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.18.0/kubectl-vault-linux-arm.tar.gz
-      sha256: 36a2d317d9437664e64f2276f84fce40f509f14c0238f83a96726ce615c54228
+      uri: https://github.com/kubevault/cli/releases/download/v0.20.0-rc.0/kubectl-vault-linux-arm.tar.gz
+      sha256: 40fffae3923c12bb82822818f721880767d91e0001da61100522554ad5033ce4
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.18.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: ac7ee249c0d178473a8969bb7c2455fb0fc650a83b9b99d2ecd1894a473efce0
+      uri: https://github.com/kubevault/cli/releases/download/v0.20.0-rc.0/kubectl-vault-linux-arm64.tar.gz
+      sha256: cb7e2b57476509175eac2a0f15bec5791ee5985e32ab485a33a1897f63f00a4e
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.18.0/kubectl-vault-windows-amd64.zip
-      sha256: d0a75a36ae17a54e7e728ce3786a5b6dfa29119c08f097897b204191975cdf12
+      uri: https://github.com/kubevault/cli/releases/download/v0.20.0-rc.0/kubectl-vault-windows-amd64.zip
+      sha256: 795ad348fa0620ff4863ad3352e75b8c5afa918392969865e8a0b8047f980b4f
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2025.2.6-rc.0

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/55
Signed-off-by: 1gtm <1gtm@appscode.com>