### PR TITLE
Publish Stash@v2025.2.10 plugin

### DIFF
--- a/plugins/stash.yaml
+++ b/plugins/stash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: stash
 spec:
-  version: v0.38.0
+  version: v0.39.0
   homepage: https://stash.run
   shortDescription: kubectl plugin for Stash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.38.0/kubectl-stash-darwin-amd64.tar.gz
-      sha256: c32a9c9731f44e6104e9ffc5ca1b956a2fbc66eb2b24c70f9022d0296392c268
+      uri: https://github.com/stashed/cli/releases/download/v0.39.0/kubectl-stash-darwin-amd64.tar.gz
+      sha256: 0e957ad940a31b053748c7a54b986cd6710f46105a819cda87ccee8db40806ba
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.38.0/kubectl-stash-darwin-arm64.tar.gz
-      sha256: 3677e9126a1c650e285c0c45f15b912dd2ab3c7488b790418ab6a96d07857d1e
+      uri: https://github.com/stashed/cli/releases/download/v0.39.0/kubectl-stash-darwin-arm64.tar.gz
+      sha256: 9f7e476d46555468e136561bba2b66bab94ff672f24baefb6c92bf6f9c443746
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.38.0/kubectl-stash-linux-amd64.tar.gz
-      sha256: af4de10f68f6f0d89bb45e537ca608807b418155a74c06c40ab0285ad0bf1d29
+      uri: https://github.com/stashed/cli/releases/download/v0.39.0/kubectl-stash-linux-amd64.tar.gz
+      sha256: 254b9d6df1f68081a4c11d4bebe151b9189ef68b4c1cd5c093532f24248d4a48
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/stashed/cli/releases/download/v0.38.0/kubectl-stash-linux-arm.tar.gz
-      sha256: cef3fcdda5d6b178bf829bc31cdbf1e32a280c491800452fddccf3e1e7fda52e
+      uri: https://github.com/stashed/cli/releases/download/v0.39.0/kubectl-stash-linux-arm.tar.gz
+      sha256: dc5b673e899c41ea08b60d483aa9e2f1d2c9d726b12a50799679544ad2234cc5
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/stashed/cli/releases/download/v0.38.0/kubectl-stash-linux-arm64.tar.gz
-      sha256: 6b155fe6bc97f17e65cffa147f5a94d9de31e1a613e70f9ec0dcab807e180e45
+      uri: https://github.com/stashed/cli/releases/download/v0.39.0/kubectl-stash-linux-arm64.tar.gz
+      sha256: 0e94f503cbea4163b4b65c5c0c6759a6f138305b940e98d76e74d9aecf162c2d
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/stashed/cli/releases/download/v0.38.0/kubectl-stash-windows-amd64.zip
-      sha256: 04266a9112663a5ac8de6901fa4c8d05ae03ade6470b45576c04243b53bdfaf2
+      uri: https://github.com/stashed/cli/releases/download/v0.39.0/kubectl-stash-windows-amd64.zip
+      sha256: 39538692b638e97167fc0d10443894baaf4e1bafc99c40f2d4a5538d283b4f41
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Stash

Release: v2025.2.10

Release-tracker: https://github.com/stashed/CHANGELOG/pull/80
Signed-off-by: 1gtm <1gtm@appscode.com>