### PR TITLE
Publish KubeStash@v2025.3.24 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.15.0
+  version: v0.16.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.15.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: 7f335c7028a1ec5068c86192d62cc51b176c44dd017f5f728177f640cec1872d
+      uri: https://github.com/kubestash/cli/releases/download/v0.16.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: 735651c7a659addc4f0496b752cc36e5739f8fe2269ef5eeaf4ec0c95fa04779
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.15.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 6402f4b39d64172a6113dea31d88450536c656959a54a49f2c2667a3165fd7f8
+      uri: https://github.com/kubestash/cli/releases/download/v0.16.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: e4914004afb53be57d247ea15af6e95a3cc264e4633de4a2a079af88165a53be
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.15.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: 9fee61b2b05ef393f39951532df24ba76d063f11041ad94122e42c599471e90e
+      uri: https://github.com/kubestash/cli/releases/download/v0.16.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: 098fb4ff0a2e426e9dcc6eb53d3a50f55b87c2951d3c45c47b6dcdd80aa850a6
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.15.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: d88fe9b29e6073a1269bb996a6b0b023751b993d935c186d2cff5a0517bdbcbb
+      uri: https://github.com/kubestash/cli/releases/download/v0.16.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: fa92dd2a666085c65d1799c173eec0dd66961d7cf56e0d400206b7104c198510
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.15.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: a8dd11551c121097d10ad6b81ce26a39fb67165fc025233bfcf8ac907965dc85
+      uri: https://github.com/kubestash/cli/releases/download/v0.16.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: 13629c0c99bbbbe1035a3828cd4ca8766835079ec7a104e326887787c9fcaa5d
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.15.0/kubectl-kubestash-windows-amd64.zip
-      sha256: cba6b0bf4585eeb7afd5aebb03b76fb0b8cf7946448854348e55686052913955
+      uri: https://github.com/kubestash/cli/releases/download/v0.16.0/kubectl-kubestash-windows-amd64.zip
+      sha256: 5be951c369aa03ff098a28bdee57b3ea210f42aef72880891409f69b99763c39
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2025.3.24

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>