### PR TITLE
Publish KubeDB@v2025.3.24 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.52.0
+  version: v0.53.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.52.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 448c678521cf8dbb4148618babada062b69233c92123bea09bfd408bd85540db
+      uri: https://github.com/kubedb/cli/releases/download/v0.53.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: fb06089d5fc92c83c48b7d9185acac7d87dd7f18405ebb9dfecf940cdf347126
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.52.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: ca8735d1500582f94f36a06bce7ec079012f56321b6e99a64c0a71f8abdcf934
+      uri: https://github.com/kubedb/cli/releases/download/v0.53.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: 5caa3fc398e792536f157a67f569ccf06c60aba572cc9fc125f114e88882cbe4
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.52.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: d1a89cc23d3b16715246ea9d472b952ee4a9bc2a06da68c777441e0f9b786311
+      uri: https://github.com/kubedb/cli/releases/download/v0.53.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 122791a94261aaefb12b22966459ef5b89878912d9eff72ff5bd640bb20895f5
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.52.0/kubectl-dba-linux-arm.tar.gz
-      sha256: ccdc7e70750902dd1f0a07eb15076c5c96c8b1c0e5176f2a3896801b1dc2ea80
+      uri: https://github.com/kubedb/cli/releases/download/v0.53.0/kubectl-dba-linux-arm.tar.gz
+      sha256: 42dda155024e14110b84995f401333aaa998b89aaf60cca8feaed4073ecbce3a
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.52.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: b2a53d7b9e3e0307e80295314dc1a9580cf79d2c2d85658f100aef363ed72d70
+      uri: https://github.com/kubedb/cli/releases/download/v0.53.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 8a404091269e7a3b4269e4912df6abdcd221fb701358668ba05df571c494803f
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.52.0/kubectl-dba-windows-amd64.zip
-      sha256: a481080d4e8390438ec64587572f6f0d3e9b956d9c7110eb9f431dcfc13510f7
+      uri: https://github.com/kubedb/cli/releases/download/v0.53.0/kubectl-dba-windows-amd64.zip
+      sha256: 9efe5ba13164829f3617fee46b1a50bac38dff4f29e1d387b51c3189771572cd
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2025.3.24

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/111
Signed-off-by: 1gtm <1gtm@appscode.com>