### PR TITLE
Publish KubeVault@v2025.5.26 plugin

### DIFF
--- a/plugins/vault.yaml
+++ b/plugins/vault.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: vault
 spec:
-  version: v0.20.0
+  version: v0.21.0
   homepage: https://kubevault.com
   shortDescription: kubectl plugin for KubeVault by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.20.0/kubectl-vault-darwin-amd64.tar.gz
-      sha256: 19e34557f00a63cb02d12678db38ccd4f87a88c58bac12503d1692dc2c11593d
+      uri: https://github.com/kubevault/cli/releases/download/v0.21.0/kubectl-vault-darwin-amd64.tar.gz
+      sha256: 8497e0a0c9ca20d14b6725bfef3a398578e85fde8d1ec8508bb48f2ae04f5658
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.20.0/kubectl-vault-darwin-arm64.tar.gz
-      sha256: cc698806dc4f33814463754630a6f4ea125560798e59a3f63005948f8ea4b3a8
+      uri: https://github.com/kubevault/cli/releases/download/v0.21.0/kubectl-vault-darwin-arm64.tar.gz
+      sha256: 5cbd88070c59f2fe8fb4be908b88ba3af8229565ca950fbc863b87c225f9efde
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.20.0/kubectl-vault-linux-amd64.tar.gz
-      sha256: 199d20d3f9b497526b3c5f1d2debc4cc1d7cada25d15b8f8ee986259e5f70069
+      uri: https://github.com/kubevault/cli/releases/download/v0.21.0/kubectl-vault-linux-amd64.tar.gz
+      sha256: db6ef9bc713dcfb7d30c5f2b9c4f89ade07b0a4d3d40f741287fba238a6054c9
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubevault/cli/releases/download/v0.20.0/kubectl-vault-linux-arm.tar.gz
-      sha256: f9a61dcc021182da0b7ebb30bc695a10621ab569dfbf1cfcb65fec855e5b5c2b
+      uri: https://github.com/kubevault/cli/releases/download/v0.21.0/kubectl-vault-linux-arm.tar.gz
+      sha256: 6de74fb09889d60d7608129c1a999c3cce749b411228fa4c682bd43bf1b935db
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubevault/cli/releases/download/v0.20.0/kubectl-vault-linux-arm64.tar.gz
-      sha256: 536e54beda55a4b52767d524f33dd4220de0c889d971f727b1c2fc2307acb7c8
+      uri: https://github.com/kubevault/cli/releases/download/v0.21.0/kubectl-vault-linux-arm64.tar.gz
+      sha256: b6776f6b11533e2524b3272b4e6b3f0a7f79057b3cebe0e3132a0944b958dd0d
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubevault/cli/releases/download/v0.20.0/kubectl-vault-windows-amd64.zip
-      sha256: a0c09eb67928f708544207953554f9fb5e2fcb8ca87fc61dfe5bc599ab8f4145
+      uri: https://github.com/kubevault/cli/releases/download/v0.21.0/kubectl-vault-windows-amd64.zip
+      sha256: ce33a2c67c4f499d0cbf9361ae21338c21f43bfcba3b235d178de7bb3cd7dc05
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeVault

Release: v2025.5.26

Release-tracker: https://github.com/kubevault/CHANGELOG/pull/58
Signed-off-by: 1gtm <1gtm@appscode.com>