### PR TITLE
Publish Voyager@v2025.5.30 plugin

### DIFF
--- a/plugins/voyager.yaml
+++ b/plugins/voyager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: voyager
 spec:
-  version: v0.0.16
+  version: v0.0.17
   homepage: https://voyagermesh.com
   shortDescription: kubectl plugin for Voyager by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.16/kubectl-voyager-darwin-amd64.tar.gz
-      sha256: 0a3a37e527b728d8a2ae448a1108f4f5fbf79a9423b4e5fcaa5a84da32678096
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.17/kubectl-voyager-darwin-amd64.tar.gz
+      sha256: 8edc31afa966375dd074a3fd10415b0b4bca000846b35fb3276d32ae0e8e3167
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.16/kubectl-voyager-darwin-arm64.tar.gz
-      sha256: 3d1538e4d23053b34209a2d180c35b3873ac86b5c94b99c0367eb2b9e3f4fd59
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.17/kubectl-voyager-darwin-arm64.tar.gz
+      sha256: 05a5a0ac834ee44a2fd1323c12f6c7c25d6bc748443ae2934c9f8f9bd3c62ce7
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.16/kubectl-voyager-linux-amd64.tar.gz
-      sha256: f6fdac2ab4132940222226acb88f9ff585d18ac01d6d611ab9954c7f4f8d870e
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.17/kubectl-voyager-linux-amd64.tar.gz
+      sha256: d3ce908c72b2f771c8cb63e5eace392c67a7a16d924f4032dc9ac62167bcc0de
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.16/kubectl-voyager-linux-arm.tar.gz
-      sha256: bf2c8662d955827309fa7a8e8078b8ca3b02513ac5ba6e9b9324e7dedc22f921
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.17/kubectl-voyager-linux-arm.tar.gz
+      sha256: dea0f58869d71c41fcbdc021dd2c35c178c46c06acedac8a3dea7bd7a9d81fa6
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.16/kubectl-voyager-linux-arm64.tar.gz
-      sha256: 1627f12b165eb191db9ae3cdc21aa95c1d49e42f51ebf064e2a8189018760c96
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.17/kubectl-voyager-linux-arm64.tar.gz
+      sha256: 28f2d3ed10ebfd67e9a54c011780397e6241087058fee96a5846745b8d7080c7
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.16/kubectl-voyager-windows-amd64.zip
-      sha256: 594d559855f08eba15414ed8af3e956417659014c68aaf43a9718db7007fac67
+      uri: https://github.com/voyagermesh/cli/releases/download/v0.0.17/kubectl-voyager-windows-amd64.zip
+      sha256: e958cd1c1a3e5b7f4a507c697bf8fe38225401b30eace771b6ea22d7b0038ed0
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: Voyager

Release: v2025.5.30

Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/36
Signed-off-by: 1gtm <1gtm@appscode.com>