### PR TITLE
Publish KubeStash@v2025.7.31 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.18.0
+  version: v0.19.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.18.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: e0e0e5e7335ee7d3c3e72d5f4e5e43deb50686c5d7469350b630fe05d7cfc551
+      uri: https://github.com/kubestash/cli/releases/download/v0.19.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: 61a2550f3abd4113ce166cb425da2898a85a0d1da3ec6eab43038e174b8907f6
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.18.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 11fa3103b7a0c12f4fdda8869cf52e3bb5d973dcb998f54f2ac8f254226164bb
+      uri: https://github.com/kubestash/cli/releases/download/v0.19.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: 64d52d1eef5f2c52543198b68ac47a77081cdc1c9161bf2651ce95de907c4c7c
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.18.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: d65995eba3a85aa7244bd6f1b7eff842ecddddea18d7521b7e8e669e14f2468b
+      uri: https://github.com/kubestash/cli/releases/download/v0.19.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: 57f5d3e5b754646621baa52aaee3598059b87207565d174ec7efa51da912e5e1
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.18.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: 2da51f88937de113aa918664ce9052129beaf911f936da3f48e57840d7495705
+      uri: https://github.com/kubestash/cli/releases/download/v0.19.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: 52d97977381debb6154ae8f0f628838194abc471b13101c268188b777b2e7b45
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.18.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: 2b5c24f5361a5d89c0cf6b901df5430e31609641c56e00c217be00d5d252e77b
+      uri: https://github.com/kubestash/cli/releases/download/v0.19.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: 565c24faa84e42a4e9d6c2c5e8819070e150ea21e1a09c1459c528403ea537ed
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.18.0/kubectl-kubestash-windows-amd64.zip
-      sha256: c06187c43def25af09761cdb7b82842723ad9fa7933a3722e0da35f3eff71ad7
+      uri: https://github.com/kubestash/cli/releases/download/v0.19.0/kubectl-kubestash-windows-amd64.zip
+      sha256: e73c8135ee24af05a1df4c57d3df41223d8ed8ad406dcea1fbfa4d2bbb621c30
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2025.7.31

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/32
Signed-off-by: 1gtm <1gtm@appscode.com>