### PR TITLE
Publish KubeStash@v2026.2.26 plugin

### DIFF
--- a/plugins/kubestash.yaml
+++ b/plugins/kubestash.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubestash
 spec:
-  version: v0.24.0
+  version: v0.25.0
   homepage: https://kubestash.com
   shortDescription: kubectl plugin for KubeStash by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.24.0/kubectl-kubestash-darwin-amd64.tar.gz
-      sha256: b6c182f9488e90f9ae319d301256abb5cea2c14258ba3f19548da8d782c0b687
+      uri: https://github.com/kubestash/cli/releases/download/v0.25.0/kubectl-kubestash-darwin-amd64.tar.gz
+      sha256: be1218ee9012185cfa1458a3167317f2dd03b616681ba8bd119091e7e8302e41
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.24.0/kubectl-kubestash-darwin-arm64.tar.gz
-      sha256: 22e3ccf10e8bb0aaeded32319594c113f4a739b160ccd3c370eca87993650dd1
+      uri: https://github.com/kubestash/cli/releases/download/v0.25.0/kubectl-kubestash-darwin-arm64.tar.gz
+      sha256: 1749d5f37749366ced58b858f5ae6f96613c7c523640e8e84a8e838cd6e488a0
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.24.0/kubectl-kubestash-linux-amd64.tar.gz
-      sha256: 5ff7a992246f52817eca5a7bf67ef05ffaa3dfb314dd982bf3d2ed4686fe21be
+      uri: https://github.com/kubestash/cli/releases/download/v0.25.0/kubectl-kubestash-linux-amd64.tar.gz
+      sha256: b404326e60d96d371a10971bf55ec2140256fd4ca3d14f3e36ea11b0b08bc17b
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubestash/cli/releases/download/v0.24.0/kubectl-kubestash-linux-arm.tar.gz
-      sha256: 8d69b556c988bf36d0112c82cda63e5284318997403ee086ba889c3c2ebada80
+      uri: https://github.com/kubestash/cli/releases/download/v0.25.0/kubectl-kubestash-linux-arm.tar.gz
+      sha256: 42fbb33e62a60f48cc8639da239ceaf7fb44c1c057bd4caaa34b010a92c308d1
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubestash/cli/releases/download/v0.24.0/kubectl-kubestash-linux-arm64.tar.gz
-      sha256: 4f261b883996b27100707a191294e6703ebed476b65b7b7a293068aa3da2c375
+      uri: https://github.com/kubestash/cli/releases/download/v0.25.0/kubectl-kubestash-linux-arm64.tar.gz
+      sha256: 038919f6178abdcaadb2c534f84ff67216a8bf6948924ee8bf039f290597c0f7
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubestash/cli/releases/download/v0.24.0/kubectl-kubestash-windows-amd64.zip
-      sha256: cf267e952b00e3fdf4a079d5531cb848202de43b867c6a303e8797cb9f385c05
+      uri: https://github.com/kubestash/cli/releases/download/v0.25.0/kubectl-kubestash-windows-amd64.zip
+      sha256: 95a5eecc30c808079dbd2d34fc622fdf2a1ec60d5baecf72c244781af90b2948
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeStash

Release: v2026.2.26

Release-tracker: https://github.com/kubestash/CHANGELOG/pull/43
Signed-off-by: 1gtm <1gtm@appscode.com>