### PR TITLE
Publish KubeDB@v2026.4.27 plugin

### DIFF
--- a/plugins/dba.yaml
+++ b/plugins/dba.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dba
 spec:
-  version: v0.63.0
+  version: v0.64.0
   homepage: https://kubedb.com
   shortDescription: kubectl plugin for KubeDB by AppsCode
   description: |
@@ -13,8 +13,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.63.0/kubectl-dba-darwin-amd64.tar.gz
-      sha256: 016ce6bab68de97e7f0302976ea91a3787eaffcf7101f696951097e087e2c55d
+      uri: https://github.com/kubedb/cli/releases/download/v0.64.0/kubectl-dba-darwin-amd64.tar.gz
+      sha256: ee15703a97f2cf9c068a336de7b2aa1e1f002efec0366706ecb59d9b64f895c6
       files:
         - from: "*"
           to: "."
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.63.0/kubectl-dba-darwin-arm64.tar.gz
-      sha256: da809da5ecfa39664afa1016be2e5351ed76ae498c12c83b420848ee1fa3a6ca
+      uri: https://github.com/kubedb/cli/releases/download/v0.64.0/kubectl-dba-darwin-arm64.tar.gz
+      sha256: bb6ef7719d9e244a8d885b745fba0a79fbfbcb5b31ec0e886e53ca31c245a28a
       files:
         - from: "*"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.63.0/kubectl-dba-linux-amd64.tar.gz
-      sha256: 27f995149cc5a32eaf5c5e0c91d03fe3969bd9ec05b043e860de7e15c3429453
+      uri: https://github.com/kubedb/cli/releases/download/v0.64.0/kubectl-dba-linux-amd64.tar.gz
+      sha256: 4e42cef786e57e67a5017f73b7921fb1cfb594a130ffb9e3914c87caca98de8a
       files:
         - from: "*"
           to: "."
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/kubedb/cli/releases/download/v0.63.0/kubectl-dba-linux-arm.tar.gz
-      sha256: 46f006832cbaa9c418afc96147041aad9b432338997fc8d5e55073b679b6bf0b
+      uri: https://github.com/kubedb/cli/releases/download/v0.64.0/kubectl-dba-linux-arm.tar.gz
+      sha256: f837c23a8673661b2c5c0a30c5400b5e2dceb05156c3ba357a34108afb7c900e
       files:
         - from: "*"
           to: "."
@@ -53,8 +53,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/kubedb/cli/releases/download/v0.63.0/kubectl-dba-linux-arm64.tar.gz
-      sha256: 23ab52481822e5f51bbbb3ca2c73a01a649cd94e98a4d5b1da299de35f74bdcd
+      uri: https://github.com/kubedb/cli/releases/download/v0.64.0/kubectl-dba-linux-arm64.tar.gz
+      sha256: 8cb7cd35f641ed0ed7904e1f8d837f075915c8768b9af4615bcca1b4f686debd
       files:
         - from: "*"
           to: "."
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kubedb/cli/releases/download/v0.63.0/kubectl-dba-windows-amd64.zip
-      sha256: e4b25b37b7ca32572570ab908300798f4b87f3018e67e9443ae5c5e63ad20099
+      uri: https://github.com/kubedb/cli/releases/download/v0.64.0/kubectl-dba-windows-amd64.zip
+      sha256: 623e4f289837394ad3bd20692c0e9e2ee8dc7eb1566cc1215e7a2ffd870a2379
       files:
         - from: "*"
           to: "."


### PR DESCRIPTION
ProductLine: KubeDB

Release: v2026.4.27

Release-tracker: https://github.com/kubedb/CHANGELOG/pull/133
Signed-off-by: 1gtm <1gtm@appscode.com>